### PR TITLE
送信を Shift+Enter または Enter から選択できるようにしました

### DIFF
--- a/src/app/projects/[projectId]/components/chatForm/ChatInput.tsx
+++ b/src/app/projects/[projectId]/components/chatForm/ChatInput.tsx
@@ -2,6 +2,7 @@ import { AlertCircleIcon, LoaderIcon, SendIcon } from "lucide-react";
 import { type FC, useCallback, useId, useRef, useState } from "react";
 import { Button } from "../../../../../components/ui/button";
 import { Textarea } from "../../../../../components/ui/textarea";
+import { useConfig } from "../../../../hooks/useConfig";
 import type { CommandCompletionRef } from "./CommandCompletion";
 import type { FileCompletionRef } from "./FileCompletion";
 import { InlineCompletion } from "./InlineCompletion";
@@ -42,6 +43,7 @@ export const ChatInput: FC<ChatInputProps> = ({
   const commandCompletionRef = useRef<CommandCompletionRef>(null);
   const fileCompletionRef = useRef<FileCompletionRef>(null);
   const helpId = useId();
+  const { config } = useConfig();
 
   const handleSubmit = async () => {
     if (!message.trim()) return;
@@ -58,9 +60,19 @@ export const ChatInput: FC<ChatInputProps> = ({
       return;
     }
 
-    if (e.key === "Enter" && e.shiftKey) {
-      e.preventDefault();
-      handleSubmit();
+    // IMEで変換中の場合は送信しない
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+      const isEnterSend = config?.enterKeyBehavior === "enter-send";
+      
+      if (isEnterSend && !e.shiftKey) {
+        // Enter: Send mode
+        e.preventDefault();
+        handleSubmit();
+      } else if (!isEnterSend && e.shiftKey) {
+        // Shift+Enter: Send mode (default)
+        e.preventDefault();
+        handleSubmit();
+      }
     }
   };
 

--- a/src/app/projects/[projectId]/components/newChat/NewChat.tsx
+++ b/src/app/projects/[projectId]/components/newChat/NewChat.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { useConfig } from "../../../../hooks/useConfig";
 import { ChatInput, useNewChatMutation } from "../chatForm";
 
 export const NewChat: FC<{
@@ -6,9 +7,18 @@ export const NewChat: FC<{
   onSuccess?: () => void;
 }> = ({ projectId, onSuccess }) => {
   const startNewChat = useNewChatMutation(projectId, onSuccess);
+  const { config } = useConfig();
 
   const handleSubmit = async (message: string) => {
     await startNewChat.mutateAsync({ message });
+  };
+
+  const getPlaceholder = () => {
+    const isEnterSend = config?.enterKeyBehavior === "enter-send";
+    if (isEnterSend) {
+      return "Type your message here... (Start with / for commands, @ for files, Enter to send)";
+    }
+    return "Type your message here... (Start with / for commands, @ for files, Shift+Enter to send)";
   };
 
   return (
@@ -17,7 +27,7 @@ export const NewChat: FC<{
       onSubmit={handleSubmit}
       isPending={startNewChat.isPending}
       error={startNewChat.error}
-      placeholder="Type your message here... (Start with / for commands, @ for files, Shift+Enter to send)"
+      placeholder={getPlaceholder()}
       buttonText="Start Chat"
       minHeight="min-h-[200px]"
       containerClassName="space-y-4"

--- a/src/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ResumeChat.tsx
+++ b/src/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ResumeChat.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { useConfig } from "../../../../../../hooks/useConfig";
 import {
   ChatInput,
   useResumeChatMutation,
@@ -11,6 +12,7 @@ export const ResumeChat: FC<{
   isRunningTask: boolean;
 }> = ({ projectId, sessionId, isPausedTask, isRunningTask }) => {
   const resumeChat = useResumeChatMutation(projectId, sessionId);
+  const { config } = useConfig();
 
   const handleSubmit = async (message: string) => {
     await resumeChat.mutateAsync({ message });
@@ -23,6 +25,14 @@ export const ResumeChat: FC<{
     return "Resume";
   };
 
+  const getPlaceholder = () => {
+    const isEnterSend = config?.enterKeyBehavior === "enter-send";
+    if (isEnterSend) {
+      return "Type your message... (Start with / for commands, Enter to send)";
+    }
+    return "Type your message... (Start with / for commands, Shift+Enter to send)";
+  };
+
   return (
     <div className="border-t border-border/50 bg-muted/20 p-4 mt-6">
       <ChatInput
@@ -30,7 +40,7 @@ export const ResumeChat: FC<{
         onSubmit={handleSubmit}
         isPending={resumeChat.isPending}
         error={resumeChat.error}
-        placeholder="Type your message... (Start with / for commands, Shift+Enter to send)"
+        placeholder={getPlaceholder()}
         buttonText={getButtonText()}
         minHeight="min-h-[100px]"
         containerClassName="space-y-2"

--- a/src/components/SettingsControls.tsx
+++ b/src/components/SettingsControls.tsx
@@ -4,6 +4,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { type FC, useCallback, useId } from "react";
 import { configQueryConfig, useConfig } from "@/app/hooks/useConfig";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { projectQueryConfig } from "../app/projects/[projectId]/hooks/useProject";
 
 interface SettingsControlsProps {
@@ -53,6 +60,15 @@ export const SettingsControls: FC<SettingsControlsProps> = ({
     await onConfigChanged();
   };
 
+  const handleEnterKeyBehaviorChange = async (value: string) => {
+    const newConfig = {
+      ...config,
+      enterKeyBehavior: value as "shift-enter-send" | "enter-send",
+    };
+    updateConfig(newConfig);
+    await onConfigChanged();
+  };
+
   return (
     <div className={`space-y-4 ${className}`}>
       <div className="flex items-center space-x-2">
@@ -97,6 +113,28 @@ export const SettingsControls: FC<SettingsControlsProps> = ({
           title
         </p>
       )}
+
+      <div className="space-y-2">
+        {showLabels && (
+          <label className="text-sm font-medium leading-none">
+            Enter Key Behavior
+          </label>
+        )}
+        <Select value={config?.enterKeyBehavior || "shift-enter-send"} onValueChange={handleEnterKeyBehaviorChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select enter key behavior" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="shift-enter-send">Shift+Enter to send (default)</SelectItem>
+            <SelectItem value="enter-send">Enter to send</SelectItem>
+          </SelectContent>
+        </Select>
+        {showDescriptions && (
+          <p className="text-xs text-muted-foreground mt-1">
+            Choose how the Enter key behaves in message input
+          </p>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/server/config/config.ts
+++ b/src/server/config/config.ts
@@ -3,6 +3,7 @@ import z from "zod";
 export const configSchema = z.object({
   hideNoUserMessageSession: z.boolean().optional().default(true),
   unifySameTitleSession: z.boolean().optional().default(true),
+  enterKeyBehavior: z.enum(["shift-enter-send", "enter-send"]).optional().default("shift-enter-send"),
 });
 
 export type Config = z.infer<typeof configSchema>;


### PR DESCRIPTION
初めまして。開発チームで便利に使わせて頂いています、ありがとうございます。
メンバーから「Enter で送信、Shift+Enter で改行 に慣れてしまったので、 claude-code-viewer でもそうしたい」との要望があったので対応してみました。

Settings に Enter Key Behavior を追加しています。

<img width="315" height="543" alt="image" src="https://github.com/user-attachments/assets/31e67b04-bb29-4056-877d-a9c8a1f5fc6d" />

### 変更点

- 設定スキーマにEnterキーの動作設定 enterKeyBehavior を追加（shift-enter-send：Shift+Enterで送信 | enter-send：Enterで送信）
- SettingsControlsコンポーネントに、Enterキーの動作を切り替える設定を実装
- ユーザーが設定したEnterキーの動作を反映するようChatInputを更新
- 日本語入力の際など、IME変換中の意図しない送信を防止するように対応
- 選択された動作に応じて、プレースホルダーのテキストが動的に変化する機能を追加

我々は Fork 版を使っていますが、マージしてもらえたら嬉しいです。

----

Hello,

First off, thank you for this great tool! Our development team has been finding it very useful.

We received a request from our team members who are accustomed to the "Send with Enter, Newline with Shift+Enter" behavior and wanted to have the same option in `claude-code-viewer`. I've implemented a solution to address this.

This adds a new "Enter Key Behavior" option to the Settings.

### Changes

- Add enterKeyBehavior setting to config schema (shift-enter-send | enter-send)
- Implement Enter key behavior toggle in SettingsControls component
- Update ChatInput to respect user's Enter key preference
- Support IME composition to prevent accidental sends during Japanese input
- Add dynamic placeholder text based on selected behavior

We are currently using this in our forked version and would be happy if you would consider merging it.

🤖 Generated with [Claude Code](https://claude.ai/code)