### PR TITLE
fix: Git Diff View works in subdirectories

### DIFF
--- a/src/server/core/git/functions/getDiff.test.ts
+++ b/src/server/core/git/functions/getDiff.test.ts
@@ -367,6 +367,44 @@ index abc123..abc123 100644`;
   });
 
   describe("エッジケース", () => {
+    it("サブディレクトリから実行しても動作する", async () => {
+      const mockCwd = "/test/repo/subdirectory";
+      const fromRef = "base:main";
+      const toRef = "compare:feature";
+
+      const mockNumstatOutput = `3\t1\tsrc/file.ts`;
+      const mockDiffOutput = `diff --git a/src/file.ts b/src/file.ts
+index abc123..def456 100644
+--- a/src/file.ts
++++ b/src/file.ts
+@@ -1,2 +1,3 @@
+ content`;
+
+      vi.mocked(utils.executeGitCommand)
+        .mockResolvedValueOnce({
+          success: true,
+          data: mockNumstatOutput,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: mockDiffOutput,
+        });
+
+      const result = await getDiff(mockCwd, fromRef, toRef);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.files).toHaveLength(1);
+        expect(result.data.files[0]?.filePath).toBe("src/file.ts");
+      }
+
+      // Verify that git commands are executed in the subdirectory
+      expect(utils.executeGitCommand).toHaveBeenCalledWith(
+        ["diff", "--numstat", "main", "feature"],
+        mockCwd,
+      );
+    });
+
     it("特殊文字を含むファイル名を処理できる", async () => {
       const mockCwd = "/test/repo";
       const fromRef = "base:main";

--- a/src/server/core/git/functions/utils.ts
+++ b/src/server/core/git/functions/utils.ts
@@ -15,7 +15,7 @@ export async function executeGitCommand(
   cwd: string,
 ): Promise<GitResult<string>> {
   try {
-    // Check if the directory exists and contains a git repository
+    // Check if the directory exists
     if (!existsSync(cwd)) {
       return {
         success: false,
@@ -27,16 +27,7 @@ export async function executeGitCommand(
       };
     }
 
-    if (!existsSync(resolve(cwd, ".git"))) {
-      return {
-        success: false,
-        error: {
-          code: "NOT_A_REPOSITORY",
-          message: `Not a git repository: ${cwd}`,
-          command: `git ${args.join(" ")}`,
-        },
-      };
-    }
+    // Git will search parent directories for .git, so we don't need to check explicitly
 
     const { stdout } = await execFileAsync("git", args, {
       cwd,

--- a/src/server/core/git/services/GitService.ts
+++ b/src/server/core/git/services/GitService.ts
@@ -33,11 +33,7 @@ const LayerImpl = Effect.gen(function* () {
         );
       }
 
-      if (!(yield* fs.exists(path.resolve(absoluteCwd, ".git")))) {
-        return yield* Effect.fail(
-          new NotARepositoryError({ cwd: absoluteCwd }),
-        );
-      }
+      // Git will search parent directories for .git, so we don't need to check explicitly
 
       const command = Command.make("git", ...args).pipe(
         Command.workingDirectory(absoluteCwd),


### PR DESCRIPTION
## Summary

Fixes #25 - Git Diff View が サブディレクトリで動作しない問題を修正しました。

## Changes

- `executeGitCommand` 関数から `.git` ディレクトリの明示的な存在チェックを削除
- `GitService.execGitCommand` から `.git` ディレクトリの明示的な存在チェックを削除
- サブディレクトリからの実行を検証するテストケースを追加

## Root Cause

`executeGitCommand` と `GitService.execGitCommand` が `.git` ディレクトリを `cwd` 直下でチェックしていたため、サブディレクトリから実行すると Git リポジトリではないと判定されていました。

## Solution

Git は親ディレクトリを再帰的に検索して `.git` を見つけるため、明示的なチェックは不要です。Git コマンド自体にリポジトリ判定を任せることで、サブディレクトリからの実行にも対応しました。

## Test Plan

- [x] 型チェック (`pnpm typecheck`)
- [x] ユニットテスト (`pnpm test`) - 全 220 テスト成功
- [x] Biome lint/format (`pnpm fix`)
- [x] サブディレクトリからの実行テストケース追加
- [ ] CI Pass
- [ ] レビュワーによる動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)