### PR TITLE
feat: Remove 4000 character limit for new chat input

### DIFF
--- a/src/app/projects/[projectId]/components/chatForm/ChatInput.tsx
+++ b/src/app/projects/[projectId]/components/chatForm/ChatInput.tsx
@@ -364,7 +364,6 @@ export const ChatInput: FC<ChatInputProps> = ({
               placeholder={placeholder}
               className={`${minHeight} resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent px-5 py-4 text-lg transition-all duration-200 placeholder:text-muted-foreground/60`}
               disabled={isPending || disabled}
-              maxLength={4000}
               aria-label={i18n._("Message input with completion support")}
               aria-describedby={helpId}
               aria-expanded={message.startsWith("/") || message.includes("@")}
@@ -422,7 +421,6 @@ export const ChatInput: FC<ChatInputProps> = ({
                 id={helpId}
               >
                 {message.length}
-                <span className="text-muted-foreground/50">/4000</span>
               </span>
               {(message.startsWith("/") || message.includes("@")) && (
                 <span className="text-xs text-blue-600 dark:text-blue-400 font-medium flex items-center gap-1">


### PR DESCRIPTION
## Summary

- チャット入力欄の4000文字制限を削除しました
- `maxLength={4000}` 属性を削除
- `/4000` という文字数上限表示を削除

## 関連Issue

Closes #38

## テスト結果

- ✅ `pnpm typecheck` 成功
- ✅ `pnpm fix` 成功
- ✅ `pnpm test` すべてのテストが成功 (245 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)