### PR TITLE
docs: Add internationalization section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Settings can be configured from the sidebar in Claude Code Viewer.
 | Notifications | None | Enables sound notifications when running session processes complete. Choose from multiple notification sounds with test playback functionality. |
 | Language | System | Interface language selection. Supports English and Japanese with automatic system detection. |
 
+## Internationalization (i18n)
+
+Claude Code Viewer currently supports **English** and **Japanese**. Adding new languages is straightforward—simply add a new `messages.json` file for your locale (see [src/i18n/locales/](./src/i18n/locales/) for examples).
+
+However, we haven't added other languages yet because we're uncertain about demand. **If you'd like support for your language, please open an issue**—we'll add it quickly!
 
 ## Alternatives & Differentiation
 


### PR DESCRIPTION
## Summary

README に国際化(i18n)に関するセクションを追加しました。

## Changes

- 現在サポートしている言語(英語・日本語)を明記
- 新しい言語の追加方法を説明(`messages.json` を追加するだけで簡単)
- 他言語の需要が不明なため現状は2言語のみサポートしていることを説明
- 言語追加のリクエストを Issue で受け付けていることを案内

## Test Plan

- [ ] CI Pass
- [ ] README の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)