### PR TITLE
fix: support array content format in queue-operation enqueue schema

### DIFF
--- a/src/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/QueueOperationConversationContent.tsx
+++ b/src/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/QueueOperationConversationContent.tsx
@@ -5,6 +5,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { normalizeQueueOperationContent } from "@/lib/conversation-schema/entry/normalizeQueueOperationContent";
 import type { QueueOperationEntry } from "@/lib/conversation-schema/entry/QueueOperationEntrySchema";
 
 export const QueueOperationConversationContent: FC<{
@@ -50,7 +51,7 @@ export const QueueOperationConversationContent: FC<{
                   Content:
                 </span>
                 <pre className="mt-1 overflow-x-auto whitespace-pre-wrap">
-                  {conversation.content}
+                  {normalizeQueueOperationContent(conversation.content)}
                 </pre>
               </div>
             )}

--- a/src/lib/conversation-schema/entry/QueueOperationEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/QueueOperationEntrySchema.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+import { QueueOperationEntrySchema } from "./QueueOperationEntrySchema";
+
+describe("QueueOperationEntrySchema", () => {
+  describe("enqueue operation", () => {
+    test("accepts old format with string content", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-12T15:01:25.792Z",
+        content: "hi, how are you today?",
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("accepts new format with array content", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        content: [{ type: "text", text: "こんにちは！" }],
+        sessionId: "9bb43739-21f2-45f2-bf3c-9270ba0dddca",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("accepts array content with multiple text items", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        content: [
+          { type: "text", text: "Hello" },
+          { type: "text", text: "World" },
+        ],
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("accepts array content with string items", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        content: ["Hello", "World"],
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("accepts array content with mixed content types", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        content: [
+          { type: "text", text: "Hello" },
+          "Plain string",
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              data: "base64data",
+              media_type: "image/png",
+            },
+          },
+        ],
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("rejects invalid timestamp", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "invalid-timestamp",
+        content: "test",
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test("rejects missing sessionId", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        content: "test",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test("rejects missing content", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("dequeue operation", () => {
+    test("accepts valid dequeue operation", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "dequeue",
+        timestamp: "2025-11-15T04:36:38.085Z",
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("rejects invalid timestamp", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "dequeue",
+        timestamp: "invalid",
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/lib/conversation-schema/entry/QueueOperationEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/QueueOperationEntrySchema.ts
@@ -1,10 +1,25 @@
 import { z } from "zod";
+import { DocumentContentSchema } from "../content/DocumentContentSchema";
+import { ImageContentSchema } from "../content/ImageContentSchema";
+import { TextContentSchema } from "../content/TextContentSchema";
+import { ToolResultContentSchema } from "../content/ToolResultContentSchema";
+
+const QueueOperationContentSchema = z.union([
+  z.string(),
+  TextContentSchema,
+  ToolResultContentSchema,
+  ImageContentSchema,
+  DocumentContentSchema,
+]);
 
 export const QueueOperationEntrySchema = z.union([
   z.object({
     type: z.literal("queue-operation"),
     operation: z.literal("enqueue"),
-    content: z.string(),
+    content: z.union([
+      z.string(),
+      z.array(z.union([z.string(), QueueOperationContentSchema])),
+    ]),
     sessionId: z.string(),
     timestamp: z.iso.datetime(),
   }),

--- a/src/lib/conversation-schema/entry/normalizeQueueOperationContent.test.ts
+++ b/src/lib/conversation-schema/entry/normalizeQueueOperationContent.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import { normalizeQueueOperationContent } from "./normalizeQueueOperationContent";
+
+describe("normalizeQueueOperationContent", () => {
+  test("returns string content as-is", () => {
+    const result = normalizeQueueOperationContent("Hello, world!");
+    expect(result).toBe("Hello, world!");
+  });
+
+  test("extracts text from single text content object", () => {
+    const result = normalizeQueueOperationContent([
+      { type: "text", text: "こんにちは！" },
+    ]);
+    expect(result).toBe("こんにちは！");
+  });
+
+  test("extracts text from multiple text content objects", () => {
+    const result = normalizeQueueOperationContent([
+      { type: "text", text: "Hello" },
+      { type: "text", text: "World" },
+    ]);
+    expect(result).toBe("Hello\nWorld");
+  });
+
+  test("extracts plain strings from array", () => {
+    const result = normalizeQueueOperationContent(["Hello", "World"]);
+    expect(result).toBe("Hello\nWorld");
+  });
+
+  test("handles mixed content array (strings and text objects)", () => {
+    const result = normalizeQueueOperationContent([
+      { type: "text", text: "Hello" },
+      "Plain string",
+      { type: "text", text: "World" },
+    ]);
+    expect(result).toBe("Hello\nPlain string\nWorld");
+  });
+
+  test("ignores non-text content types (image)", () => {
+    const result = normalizeQueueOperationContent([
+      { type: "text", text: "Before image" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          data: "base64data",
+          media_type: "image/png",
+        },
+      },
+      { type: "text", text: "After image" },
+    ]);
+    expect(result).toBe("Before image\n[Image]\nAfter image");
+  });
+
+  test("handles document content", () => {
+    const result = normalizeQueueOperationContent([
+      { type: "text", text: "Text" },
+      {
+        type: "document",
+        source: {
+          type: "base64",
+          data: "base64data",
+          media_type: "application/pdf",
+        },
+      },
+    ]);
+    expect(result).toBe("Text\n[Document]");
+  });
+
+  test("handles tool_result content", () => {
+    const result = normalizeQueueOperationContent([
+      { type: "text", text: "Text" },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-123",
+        content: "Tool output",
+        is_error: false,
+      },
+    ]);
+    expect(result).toBe("Text\n[Tool Result]");
+  });
+
+  test("handles empty array", () => {
+    const result = normalizeQueueOperationContent([]);
+    expect(result).toBe("");
+  });
+
+  test("handles array with only non-text content", () => {
+    const result = normalizeQueueOperationContent([
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          data: "base64data",
+          media_type: "image/png",
+        },
+      },
+    ]);
+    expect(result).toBe("[Image]");
+  });
+});

--- a/src/lib/conversation-schema/entry/normalizeQueueOperationContent.ts
+++ b/src/lib/conversation-schema/entry/normalizeQueueOperationContent.ts
@@ -1,0 +1,53 @@
+import type { QueueOperationEntry } from "./QueueOperationEntrySchema";
+
+type EnqueueContent = Extract<
+  QueueOperationEntry,
+  { operation: "enqueue" }
+>["content"];
+
+/**
+ * Normalizes queue operation content to a string for display.
+ * Handles both legacy string format and new array format.
+ *
+ * @param content - Queue operation content (string or array)
+ * @returns Normalized string representation
+ */
+export const normalizeQueueOperationContent = (
+  content: EnqueueContent,
+): string => {
+  // Legacy format: string
+  if (typeof content === "string") {
+    return content;
+  }
+
+  // New format: array of content items
+  return content
+    .map((item) => {
+      // Plain string in array
+      if (typeof item === "string") {
+        return item;
+      }
+
+      // Discriminate by type field
+      if (item.type === "text") {
+        return item.text;
+      }
+
+      if (item.type === "image") {
+        return "[Image]";
+      }
+
+      if (item.type === "document") {
+        return "[Document]";
+      }
+
+      if (item.type === "tool_result") {
+        return "[Tool Result]";
+      }
+
+      // Exhaustiveness check
+      const _exhaustive: never = item;
+      return _exhaustive;
+    })
+    .join("\n");
+};


### PR DESCRIPTION
## Summary
Fix schema parse error for queue-operation enqueue messages that use the new array content format. The schema was expecting only string content, but Claude Code now sends content as an array of content objects (e.g., `[{"type":"text","text":"こんにちは!"}]`).

## Changes
- Updated `QueueOperationEntrySchema` to accept both string and array content formats (backward compatible)
- Created `QueueOperationContentSchema` union to support text/image/document/tool-result content types
- Added helper function `normalizeQueueOperationContent` to convert both formats to displayable text
- Updated `QueueOperationConversationContent` component to handle both content formats
- Added comprehensive tests for schema validation and content normalization

## Testing
- [ ] CI Pass
- [x] Unit tests added for both old string format and new array format
- [x] Type checking passed (`pnpm typecheck`)
- [x] Linting and formatting passed (`pnpm fix`)