### PR TITLE
fix: extend MCP launch timeout from 20s to 60s

### DIFF
--- a/src/app/projects/[projectId]/components/chatForm/useChatMutations.ts
+++ b/src/app/projects/[projectId]/components/chatForm/useChatMutations.ts
@@ -24,7 +24,7 @@ export const useCreateSessionProcessMutation = (
         },
         {
           init: {
-            signal: AbortSignal.timeout(20 * 1000),
+            signal: AbortSignal.timeout(60 * 1000),
           },
         },
       );
@@ -73,7 +73,7 @@ export const useContinueSessionProcessMutation = (
         },
         {
           init: {
-            signal: AbortSignal.timeout(20 * 1000),
+            signal: AbortSignal.timeout(60 * 1000),
           },
         },
       );


### PR DESCRIPTION
## Summary

CC IntegrationのMCP起動時のタイムアウトを20秒から60秒に延長しました。OAuth承認フローを含む場合でも十分な待機時間を確保するための変更です。

Fixes #96

## Changes

- `useChatMutations.ts`の`useCreateSessionProcessMutation`と`useContinueSessionProcessMutation`のタイムアウトを20秒から60秒に変更

## Testing

- [ ] CI Pass
- [x] Type check passed (`pnpm typecheck`)
- [x] Linting passed (`pnpm fix`)