### PR TITLE
feat: add HOSTNAME environment variable for remote (container etc) access

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -3,3 +3,6 @@ DEV_BE_PORT=3401
 
 # Authentication password
 CLAUDE_CODE_VIEWER_AUTH_PASSWORD=your-secure-password-here
+
+# Server hostname (use 0.0.0.0 to bind to all interfaces for remote access)
+# HOSTNAME=localhost

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3400 \
+    HOSTNAME=0.0.0.0 \
     PATH="/app/node_modules/.bin:${PATH}"
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -120,12 +120,16 @@ const port = isDevelopment
   : // biome-ignore lint/style/noProcessEnv: allow only here
     (process.env.PORT ?? "3000");
 
+// biome-ignore lint/style/noProcessEnv: allow only here
+const hostname = process.env.HOSTNAME ?? "localhost";
+
 serve(
   {
     fetch: honoApp.fetch,
     port: parseInt(port, 10),
+    hostname,
   },
   (info) => {
-    console.log(`Server is running on http://localhost:${info.port}`);
+    console.log(`Server is running on http://${info.address}:${info.port}`);
   },
 );


### PR DESCRIPTION
Adds support for configuring the server hostname via the HOSTNAME environment variable. This enables binding to all interfaces (0.0.0.0) for remote access scenarios like:
- Running in containers/VMs accessed from the host
- Development environments with remote clients
- Mobile/embedded Linux deployments

Changes:
- Add HOSTNAME env var support in src/server/main.ts (defaults to localhost)
- Update Dockerfile to use HOSTNAME=0.0.0.0 for container deployments
- Document the option in .env.local.sample
- Update console log to show actual bound address

Usage:
  HOSTNAME=0.0.0.0 PORT=8080 npx @kimuson/claude-code-viewer@latest