### PR TITLE
fix: correct start script path from index.js to main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "run-p 'dev:*'",
     "dev:frontend": "vite",
     "dev:backend": "NODE_ENV=development tsx watch src/server/main.ts --env-file-if-exists=.env.local",
-    "start": "node dist/index.js",
+    "start": "node dist/main.js",
     "build": "./scripts/build.sh",
     "build:frontend": "vite build",
     "build:backend": "esbuild src/server/main.ts --format=esm --bundle --packages=external --sourcemap --platform=node --outfile=dist/main.js",


### PR DESCRIPTION
## Summary
- The build outputs to `dist/main.js` but the start script was pointing to `dist/index.js`
- This caused "Cannot find module" error when running `pnpm start`

## Test plan
- [ ] Run `pnpm build && pnpm start` and verify the server starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)