### PR TITLE
fix: add schema support for Claude Code v2.0.76+ entry types

### DIFF
--- a/src/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationItem.tsx
+++ b/src/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationItem.tsx
@@ -42,11 +42,13 @@ export const ConversationItem: FC<{
   }
 
   if (conversation.type === "system") {
-    return (
-      <SystemConversationContent>
-        {conversation.content}
-      </SystemConversationContent>
-    );
+    const content =
+      "content" in conversation && typeof conversation.content === "string"
+        ? conversation.content
+        : conversation.subtype === "stop_hook_summary"
+          ? `Stop hook executed: ${conversation.hookInfos.map((h) => h.command).join(", ")}`
+          : "System message";
+    return <SystemConversationContent>{content}</SystemConversationContent>;
   }
 
   if (conversation.type === "file-history-snapshot") {

--- a/src/lib/conversation-schema/entry/QueueOperationEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/QueueOperationEntrySchema.ts
@@ -29,6 +29,12 @@ export const QueueOperationEntrySchema = z.union([
     sessionId: z.string(),
     timestamp: z.iso.datetime(),
   }),
+  z.object({
+    type: z.literal("queue-operation"),
+    operation: z.literal("remove"),
+    sessionId: z.string(),
+    timestamp: z.iso.datetime(),
+  }),
 ]);
 
 export type QueueOperationEntry = z.infer<typeof QueueOperationEntrySchema>;

--- a/src/lib/conversation-schema/entry/SystemEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/SystemEntrySchema.ts
@@ -1,14 +1,47 @@
 import { z } from "zod";
 import { BaseEntrySchema } from "./BaseEntrySchema";
 
-export const SystemEntrySchema = BaseEntrySchema.extend({
-  // discriminator
-  type: z.literal("system"),
+// Hook info for stop_hook_summary
+const HookInfoSchema = z.object({
+  command: z.string(),
+});
 
-  // required
+// Base system entry with content (original format)
+const SystemEntryWithContentSchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
   content: z.string(),
   toolUseID: z.string(),
   level: z.enum(["info"]),
+  subtype: z.undefined().optional(),
 });
+
+// Stop hook summary entry (new format from Claude Code v2.0.76+)
+const StopHookSummaryEntrySchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
+  subtype: z.literal("stop_hook_summary"),
+  toolUseID: z.string(),
+  level: z.enum(["info", "suggestion"]),
+  slug: z.string().optional(),
+  hookCount: z.number(),
+  hookInfos: z.array(HookInfoSchema),
+  hookErrors: z.array(z.unknown()),
+  preventedContinuation: z.boolean(),
+  stopReason: z.string(),
+  hasOutput: z.boolean(),
+});
+
+// Local command entry (e.g., /mcp, /help commands)
+const LocalCommandEntrySchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
+  subtype: z.literal("local_command"),
+  content: z.string(),
+  level: z.enum(["info"]),
+});
+
+export const SystemEntrySchema = z.union([
+  StopHookSummaryEntrySchema,
+  LocalCommandEntrySchema,
+  SystemEntryWithContentSchema,
+]);
 
 export type SystemEntry = z.infer<typeof SystemEntrySchema>;

--- a/src/server/core/session/services/ExportService.ts
+++ b/src/server/core/session/services/ExportService.ts
@@ -227,11 +227,28 @@ const renderAssistantEntry = (
 };
 
 /**
+ * Gets the content to display for a system entry
+ */
+const getSystemEntryContent = (
+  entry: Extract<Conversation, { type: "system" }>,
+): string => {
+  if ("content" in entry && typeof entry.content === "string") {
+    return entry.content;
+  }
+  if ("subtype" in entry && entry.subtype === "stop_hook_summary") {
+    const hookNames = entry.hookInfos.map((h) => h.command).join(", ");
+    return `Stop hook executed: ${hookNames}`;
+  }
+  return "System message";
+};
+
+/**
  * Renders a system message entry
  */
 const renderSystemEntry = (
   entry: Extract<Conversation, { type: "system" }>,
 ): string => {
+  const content = getSystemEntryContent(entry);
   return `
     <div class="conversation-entry system-entry">
       <div class="entry-header">
@@ -239,7 +256,7 @@ const renderSystemEntry = (
         <span class="entry-timestamp">${formatTimestamp(entry.timestamp)}</span>
       </div>
       <div class="entry-content">
-        <div class="system-message">${escapeHtml(entry.content)}</div>
+        <div class="system-message">${escapeHtml(content)}</div>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary
- Add `stop_hook_summary` subtype to SystemEntrySchema for hook execution summaries
- Add `local_command` subtype to SystemEntrySchema for slash commands (/mcp, /help, etc.)
- Add `remove` operation to QueueOperationEntrySchema
- Update ConversationItem and ExportService to handle system entries without `content` field

These changes fix "Schema Validation Error" warnings when viewing sessions created with Claude Code v2.0.76+.

## Test plan
- [ ] View a session created with Claude Code v2.0.76+ that contains hook summaries
- [ ] View a session that used local commands like `/mcp`
- [ ] Verify no schema validation errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)