### PR TITLE
feat: display full timestamp in search results

### DIFF
--- a/src/components/SearchDialog.tsx
+++ b/src/components/SearchDialog.tsx
@@ -8,7 +8,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { useConfig } from "../app/hooks/useConfig";
 import { searchQuery } from "../lib/api/queries";
+import { formatLocaleDate } from "../lib/date/formatLocaleDate";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Input } from "./ui/input";
 
@@ -23,6 +25,7 @@ export function SearchDialog({
   onOpenChange,
   projectId,
 }: SearchDialogProps) {
+  const { config } = useConfig();
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -173,7 +176,10 @@ export function SearchDialog({
                         {result.snippet}
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        {new Date(result.timestamp).toLocaleDateString()}
+                        {formatLocaleDate(result.timestamp, {
+                          locale: config.locale,
+                          target: "time",
+                        })}
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
Replace `toLocaleDateString()` with `formatLocaleDate()` in `SearchDialog.tsx` to show both date and time for search results, matching the format used in the sidebar session list.

Previously, search results only showed the date (e.g., "12/29/2025"), which made it hard to find the specific conversation point in very busy sessions. Now they display the full timestamp (e.g., "12/29/2025 16:30"), providing better context and consistency with the sidebar.

This was my only gripe while using this kick ass tool. Glad to contribute a small improvement!!

Changes:
- Import formatLocaleDate utility and useConfig hook
- Use formatLocaleDate with user's locale preference and "time" target
- Match the MM/dd/yyyy HH:mm format used in SessionsTab