### PR TITLE
docs: add NODE_ENV requirement and privacy policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ The application reads Claude Code conversation logs from:
 
 **Note on Version Support**: Recent versions of Claude Code have adopted more aggressive summarization behavior. To accommodate users who prefer to pin to specific versions, Claude Code Viewer maintains compatibility with Claude Code v1.0.50 and later for the foreseeable future.
 
+### Environment Variables
+
+**NODE_ENV Consideration**: If you have `NODE_ENV=development` set in your environment (from other projects or system configuration), the application may not work correctly. Either set `NODE_ENV=production` or leave it unset when running Claude Code Viewer.
+
 ## Configuration
 
 ### Command-Line Options and Environment Variables
@@ -223,6 +227,17 @@ Claude Code Viewer is designed with remote hosting in mind. To support remote de
 - **System Monitoring**: Monitor Claude Code compatibility and feature availability across environments
 
 The application features a separated client-server architecture that enables remote hosting. **Basic password authentication is available** via the `--password` command-line option or `CCV_PASSWORD` environment variable. When set, users must authenticate with the configured password before accessing the application. However, this is a simple single-password authentication mechanism without advanced features like multi-user support, role-based access control, or OAuth integration. If you require more sophisticated authentication, carefully evaluate your security requirements and implement appropriate access controls at the infrastructure level (e.g., reverse proxy with OAuth, VPN, IP whitelisting).
+
+## Privacy and Network Communication
+
+Claude Code Viewer is designed with privacy in mind:
+
+- **Localhost-Only Communication**: The application runs a web client and API server on localhost, communicating exclusively between your browser and the local server
+- **Anthropic API Access**: Claude Code is invoked via the Claude Agent SDK, which handles communication to the Anthropic API. No other external services are contacted
+- **No Tracking or Telemetry**: The application does not collect crash reports, usage statistics, or any other telemetry. Tracking for Claude Code itself follows the settings configured in Claude Code's own configuration
+- **Network Isolation**: The application functions correctly even if network access is restricted to only the Anthropic API and the localhost port. There are no plans to add external network dependencies in the future
+
+If you have concerns about network access, you can verify that the application only communicates with the Anthropic API and localhost by monitoring network traffic.
 
 ## License
 


### PR DESCRIPTION
## Summary

This PR updates README.md to address issues #115 and #114 by adding:
1. NODE_ENV environment variable considerations
2. Privacy policy section explaining network communication

## Changes

- Added "Environment Variables" section documenting NODE_ENV requirement (#115)
  - Explains that `NODE_ENV=development` may cause issues
  - Recommends setting `NODE_ENV=production` or leaving it unset
- Added "Privacy and Network Communication" section (#114)
  - Documents localhost-only communication between client and server
  - Clarifies Anthropic API access via Claude Agent SDK
  - States no tracking or telemetry
  - Emphasizes network isolation (localhost + Anthropic API only)

## Testing

- [x] CI Pass
- [x] Content reviewed in session 1 with QA checks passed
- [x] README formatting verified

Related #115
Related #114