### PR TITLE
chore: add CLAUDE.local.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ dist/*
 
 # claude code
 .claude/settings.local.json
+CLAUDE.local.md
 
 # cc-delegate
 .cc-delegate/


### PR DESCRIPTION
This file contains user-specific project instructions that should not be committed to the repository.