### PR TITLE
fix: add missing schema types for Claude Code v2.1.x

### DIFF
--- a/src/lib/conversation-schema/entry/QueueOperationEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/QueueOperationEntrySchema.test.ts
@@ -125,4 +125,27 @@ describe("QueueOperationEntrySchema", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe("popAll operation", () => {
+    test("accepts valid popAll operation with content", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "popAll",
+        timestamp: "2026-01-12T08:10:11.883Z",
+        sessionId: "e3e4a2ef-c6b5-4c39-a1f9-713a943be524",
+        content: "the session has total_ammount",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("accepts popAll operation without content", () => {
+      const result = QueueOperationEntrySchema.safeParse({
+        type: "queue-operation",
+        operation: "popAll",
+        timestamp: "2026-01-12T08:10:11.883Z",
+        sessionId: "abc123",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/src/lib/conversation-schema/entry/QueueOperationEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/QueueOperationEntrySchema.ts
@@ -35,6 +35,13 @@ export const QueueOperationEntrySchema = z.union([
     sessionId: z.string(),
     timestamp: z.iso.datetime(),
   }),
+  z.object({
+    type: z.literal("queue-operation"),
+    operation: z.literal("popAll"),
+    sessionId: z.string(),
+    timestamp: z.iso.datetime(),
+    content: z.string().optional(),
+  }),
 ]);
 
 export type QueueOperationEntry = z.infer<typeof QueueOperationEntrySchema>;

--- a/src/lib/conversation-schema/entry/SystemEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/SystemEntrySchema.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { SystemEntrySchema } from "./SystemEntrySchema";
+
+describe("SystemEntrySchema", () => {
+  describe("turn_duration subtype", () => {
+    test("accepts valid turn_duration entry", () => {
+      const result = SystemEntrySchema.safeParse({
+        parentUuid: "be2d3283-d532-4771-9106-737788998164",
+        isSidechain: false,
+        userType: "external",
+        cwd: "/home/user/projects/my-app",
+        sessionId: "e3e4a2ef-c6b5-4c39-a1f9-713a943be524",
+        version: "2.1.5",
+        gitBranch: "develop",
+        slug: "declarative-snuggling-quokka",
+        type: "system",
+        subtype: "turn_duration",
+        durationMs: 325282,
+        timestamp: "2026-01-12T08:21:45.506Z",
+        uuid: "787e1f01-c75d-42e8-858d-2c3117b79fb7",
+        isMeta: false,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("accepts turn_duration entry without optional fields", () => {
+      const result = SystemEntrySchema.safeParse({
+        parentUuid: null,
+        isSidechain: false,
+        userType: "external",
+        cwd: "/some/path",
+        sessionId: "abc123",
+        version: "2.1.5",
+        type: "system",
+        subtype: "turn_duration",
+        durationMs: 42967,
+        timestamp: "2026-01-09T11:57:15.634Z",
+        uuid: "c6a15d05-e435-4588-aff3-37e173f0b8a9",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("rejects turn_duration entry without durationMs", () => {
+      const result = SystemEntrySchema.safeParse({
+        parentUuid: null,
+        isSidechain: false,
+        userType: "external",
+        cwd: "/some/path",
+        sessionId: "abc123",
+        version: "2.1.5",
+        type: "system",
+        subtype: "turn_duration",
+        timestamp: "2026-01-09T11:57:15.634Z",
+        uuid: "c6a15d05-e435-4588-aff3-37e173f0b8a9",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/lib/conversation-schema/entry/SystemEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/SystemEntrySchema.ts
@@ -38,10 +38,19 @@ const LocalCommandEntrySchema = BaseEntrySchema.extend({
   level: z.enum(["info"]),
 });
 
+// Turn duration entry (tracks duration of assistant turns, Claude Code v2.1+)
+const TurnDurationEntrySchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
+  subtype: z.literal("turn_duration"),
+  durationMs: z.number(),
+  slug: z.string().optional(),
+});
+
 export const SystemEntrySchema = z.union([
   StopHookSummaryEntrySchema,
   LocalCommandEntrySchema,
-  SystemEntryWithContentSchema,
+  TurnDurationEntrySchema,
+  SystemEntryWithContentSchema, // Must be last (catch-all for undefined subtype)
 ]);
 
 export type SystemEntry = z.infer<typeof SystemEntrySchema>;


### PR DESCRIPTION
Add support for two new JSONL entry types introduced in Claude Code v2.1:

- queue-operation with operation "popAll"
- system with subtype "turn_duration"

These entries were causing schema validation errors in the viewer.