### PR TITLE
Set a size for delete session dialog and truncate overlong title message 

### DIFF
--- a/src/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/DeleteSessionDialog.tsx
+++ b/src/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/DeleteSessionDialog.tsx
@@ -67,12 +67,12 @@ export const DeleteSessionDialog: FC<DeleteSessionDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-auto">
         <DialogHeader>
           <DialogTitle>
             <Trans id="session.delete_dialog.title" />
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="break-words line-clamp-10">
             <Trans
               id="session.delete_dialog.description"
               values={{ title: sessionTitle }}


### PR DESCRIPTION
Set a size for delete session dialog and truncate overlong title message 

this could be helpful it when delete a seesion which has a too long initial message (e.g. resumed from a compated session)