### PR TITLE
feat: render newlines in user messages and add Esc key to abort sessions

### DIFF
--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -612,7 +612,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        670
+        695
       ]
     ],
     "translation": "Recent sessions"
@@ -627,11 +627,11 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        388
+        413
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        658
+        683
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",
@@ -873,11 +873,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        255
+        262
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        263
+        270
       ]
     ],
     "translation": "No Agent"
@@ -889,7 +889,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        289
+        296
       ]
     ],
     "translation": "Select agent"
@@ -925,7 +925,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        180
+        187
       ]
     ],
     "translation": "Accept Edits"
@@ -937,7 +937,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        186
+        193
       ]
     ],
     "translation": "Bypass"
@@ -949,7 +949,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        177
+        184
       ]
     ],
     "translation": "Default"
@@ -961,7 +961,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        189
+        196
       ]
     ],
     "translation": "Plan"
@@ -973,7 +973,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        196
+        203
       ]
     ],
     "translation": "Select permission mode"
@@ -985,7 +985,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        231
+        238
       ]
     ],
     "translation": "Include default Claude Code prompt"
@@ -1187,7 +1187,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        515
+        540
       ]
     ],
     "translation": "Branch"
@@ -1198,7 +1198,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        496
+        521
       ]
     ],
     "translation": "Metadata"
@@ -1209,7 +1209,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        542
+        567
       ]
     ],
     "translation": "Model"
@@ -1243,7 +1243,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        502
+        527
       ]
     ],
     "translation": "Project Path"
@@ -1278,7 +1278,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        529
+        554
       ]
     ],
     "translation": "Session ID"
@@ -3091,7 +3091,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        149
+        151
+      ],
+      [
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
+        156
       ]
     ],
     "translation": "Abort"
@@ -3102,7 +3106,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        596
+        621
       ]
     ],
     "translation": "Cache creation"
@@ -3113,7 +3117,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        610
+        635
       ]
     ],
     "translation": "Cache read"
@@ -3124,7 +3128,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        568
+        593
       ]
     ],
     "translation": "Input tokens"
@@ -3135,7 +3139,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        555
+        580
       ]
     ],
     "translation": "Session Cost"
@@ -3146,7 +3150,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        582
+        607
       ]
     ],
     "translation": "Output tokens"
@@ -3157,7 +3161,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        562
+        587
       ]
     ],
     "translation": "Total"
@@ -3207,7 +3211,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        489
+        514
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/DeleteSessionDialog.tsx",
@@ -3226,7 +3230,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        661
+        686
       ]
     ],
     "translation": "Start a new chat to begin the conversation"
@@ -3237,7 +3241,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        479
+        504
       ]
     ],
     "translation": "Copy session file path"
@@ -3248,7 +3252,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        457
+        482
       ]
     ],
     "translation": "Export to HTML"
@@ -3259,7 +3263,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        466
+        491
       ]
     ],
     "translation": "Export to JSONL"
@@ -3270,7 +3274,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        750
+        775
       ]
     ],
     "translation": "Claude Code is processing..."
@@ -3318,7 +3322,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        715
+        740
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",
@@ -3337,7 +3341,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        713
+        738
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -612,7 +612,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        670
+        695
       ]
     ],
     "translation": "最近のセッション"
@@ -627,11 +627,11 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        388
+        413
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        658
+        683
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",
@@ -873,11 +873,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        255
+        262
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        263
+        270
       ]
     ],
     "translation": "エージェントなし"
@@ -889,7 +889,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        289
+        296
       ]
     ],
     "translation": "エージェントを選択"
@@ -925,7 +925,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        180
+        187
       ]
     ],
     "translation": "編集許可"
@@ -937,7 +937,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        186
+        193
       ]
     ],
     "translation": "バイパス"
@@ -949,7 +949,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        177
+        184
       ]
     ],
     "translation": "デフォルト"
@@ -961,7 +961,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        189
+        196
       ]
     ],
     "translation": "プラン"
@@ -973,7 +973,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        196
+        203
       ]
     ],
     "translation": "権限モードを選択"
@@ -985,7 +985,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        231
+        238
       ]
     ],
     "translation": "デフォルトの Claude Code プロンプトを含める"
@@ -1187,7 +1187,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        515
+        540
       ]
     ],
     "translation": "ブランチ"
@@ -1198,7 +1198,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        496
+        521
       ]
     ],
     "translation": "メタデータ"
@@ -1209,7 +1209,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        542
+        567
       ]
     ],
     "translation": "モデル"
@@ -1243,7 +1243,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        502
+        527
       ]
     ],
     "translation": "プロジェクトパス"
@@ -1278,7 +1278,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        529
+        554
       ]
     ],
     "translation": "セッションID"
@@ -3091,7 +3091,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        149
+        151
+      ],
+      [
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
+        156
       ]
     ],
     "translation": "中止"
@@ -3102,7 +3106,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        596
+        621
       ]
     ],
     "translation": "キャッシュ作成"
@@ -3113,7 +3117,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        610
+        635
       ]
     ],
     "translation": "キャッシュ読込"
@@ -3124,7 +3128,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        568
+        593
       ]
     ],
     "translation": "入力トークン"
@@ -3135,7 +3139,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        555
+        580
       ]
     ],
     "translation": "セッションコスト"
@@ -3146,7 +3150,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        582
+        607
       ]
     ],
     "translation": "出力トークン"
@@ -3157,7 +3161,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        562
+        587
       ]
     ],
     "translation": "合計"
@@ -3207,7 +3211,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        489
+        514
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/DeleteSessionDialog.tsx",
@@ -3226,7 +3230,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        661
+        686
       ]
     ],
     "translation": "新しいチャットを開始して会話を始めましょう"
@@ -3237,7 +3241,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        479
+        504
       ]
     ],
     "translation": "セッションファイルのパスをコピー"
@@ -3248,7 +3252,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        457
+        482
       ]
     ],
     "translation": "HTML をエクスポート"
@@ -3259,7 +3263,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        466
+        491
       ]
     ],
     "translation": "JSONL をエクスポート"
@@ -3270,7 +3274,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        750
+        775
       ]
     ],
     "translation": "Claude Codeが処理中..."
@@ -3318,7 +3322,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        715
+        740
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",
@@ -3337,7 +3341,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        713
+        738
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -612,7 +612,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        670
+        695
       ]
     ],
     "translation": "最近会话"
@@ -627,11 +627,11 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        388
+        413
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        658
+        683
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",
@@ -873,11 +873,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        255
+        262
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        263
+        270
       ]
     ],
     "translation": "无代理"
@@ -889,7 +889,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        289
+        296
       ]
     ],
     "translation": "选择代理"
@@ -925,7 +925,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        180
+        187
       ]
     ],
     "translation": "接受编辑"
@@ -937,7 +937,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        186
+        193
       ]
     ],
     "translation": "跳过"
@@ -949,7 +949,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        177
+        184
       ]
     ],
     "translation": "默认"
@@ -961,7 +961,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        189
+        196
       ]
     ],
     "translation": "计划"
@@ -973,7 +973,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        196
+        203
       ]
     ],
     "translation": "选择权限模式"
@@ -985,7 +985,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        231
+        238
       ]
     ],
     "translation": "包含默认 Claude Code 提示词"
@@ -1187,7 +1187,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        515
+        540
       ]
     ],
     "translation": "分支"
@@ -1198,7 +1198,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        496
+        521
       ]
     ],
     "translation": "元数据"
@@ -1209,7 +1209,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        542
+        567
       ]
     ],
     "translation": "模型"
@@ -1243,7 +1243,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        502
+        527
       ]
     ],
     "translation": "项目路径"
@@ -1278,7 +1278,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        529
+        554
       ]
     ],
     "translation": "会话 ID"
@@ -3091,7 +3091,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
-        149
+        151
+      ],
+      [
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx",
+        156
       ]
     ],
     "translation": "中止"
@@ -3102,7 +3106,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        596
+        621
       ]
     ],
     "translation": "缓存创建"
@@ -3113,7 +3117,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        610
+        635
       ]
     ],
     "translation": "缓存读取"
@@ -3124,7 +3128,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        568
+        593
       ]
     ],
     "translation": "输入令牌"
@@ -3135,7 +3139,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        555
+        580
       ]
     ],
     "translation": "会话成本"
@@ -3146,7 +3150,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        582
+        607
       ]
     ],
     "translation": "输出令牌"
@@ -3157,7 +3161,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        562
+        587
       ]
     ],
     "translation": "总计"
@@ -3207,7 +3211,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        489
+        514
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/DeleteSessionDialog.tsx",
@@ -3226,7 +3230,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        661
+        686
       ]
     ],
     "translation": "开始新对话以展开交流"
@@ -3237,7 +3241,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        479
+        504
       ]
     ],
     "translation": "复制会话文件路径"
@@ -3248,7 +3252,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        457
+        482
       ]
     ],
     "translation": "导出为 HTML"
@@ -3259,7 +3263,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        466
+        491
       ]
     ],
     "translation": "导出为 JSONL"
@@ -3270,7 +3274,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        750
+        775
       ]
     ],
     "translation": "Claude Code 正在处理..."
@@ -3318,7 +3322,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        715
+        740
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",
@@ -3337,7 +3341,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx",
-        713
+        738
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/sessionSidebar/SessionsTab.tsx",

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/SessionPageMain.tsx
@@ -332,6 +332,31 @@ const SessionPageMainContent: FC<
     hadVirtualMessageRef.current = hasVirtualMessage;
   }, [virtualMessages, sessionId, scrollToBottomSettled]);
 
+  // Esc key to abort running session
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (effectiveSessionStatus !== "running") return;
+      if (!relatedSessionProcess) return;
+      if (abortTask.isPending) return;
+
+      const activeEl = document.activeElement;
+      const tagName = activeEl?.tagName?.toLowerCase();
+      if (
+        tagName === "input" ||
+        tagName === "textarea" ||
+        activeEl?.getAttribute("contenteditable") === "true"
+      ) {
+        return;
+      }
+
+      abortTask.mutate(relatedSessionProcess.id);
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [effectiveSessionStatus, relatedSessionProcess, abortTask]);
+
   const sessionTitle = resolveSessionTitle(
     sessionData?.session.meta.customTitle ?? null,
     sessionData?.session.meta.firstUserMessage ?? null,

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.test.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { convertNewlinesToBreaks } from "./UserTextContent";
+
+describe("convertNewlinesToBreaks", () => {
+  test("converts single newline to hard line break", () => {
+    expect(convertNewlinesToBreaks("hello\nworld")).toBe("hello  \nworld");
+  });
+
+  test("converts multiple newlines to hard line breaks", () => {
+    expect(convertNewlinesToBreaks("a\nb\nc")).toBe("a  \nb  \nc");
+  });
+
+  test("does not add extra spaces when trailing spaces already exist", () => {
+    expect(convertNewlinesToBreaks("hello  \nworld")).toBe("hello  \nworld");
+  });
+
+  test("preserves double newlines as paragraph breaks", () => {
+    expect(convertNewlinesToBreaks("hello\n\nworld")).toBe("hello\n\nworld");
+  });
+
+  test("returns unchanged string when no newlines", () => {
+    expect(convertNewlinesToBreaks("hello world")).toBe("hello world");
+  });
+
+  test("returns empty string unchanged", () => {
+    expect(convertNewlinesToBreaks("")).toBe("");
+  });
+});

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.tsx
@@ -5,6 +5,23 @@ import { Badge } from "@/web/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/web/components/ui/card";
 import { CopyableMarkdownContent } from "./CopyableMarkdownContent";
 
+/**
+ * Convert single newlines to Markdown hard line breaks (two trailing spaces + newline).
+ * Preserves double newlines (paragraph breaks) and avoids adding extra spaces
+ * to lines that already end with 2+ spaces.
+ */
+export const convertNewlinesToBreaks = (text: string): string => {
+  // Replace single \n (not preceded or followed by \n) where the preceding text
+  // doesn't already end with 2+ spaces
+  return text.replace(/(?<!\n)( *)\n(?!\n)/g, (match, trailingSpaces: string) => {
+    if (trailingSpaces.length >= 2) {
+      // Already has hard line break formatting
+      return match;
+    }
+    return `  \n`;
+  });
+};
+
 export const UserTextContent: FC<{ text: string; id?: string }> = ({ text, id }) => {
   const parsed = parseUserMessage(text);
 
@@ -83,7 +100,7 @@ export const UserTextContent: FC<{ text: string; id?: string }> = ({ text, id })
   return (
     <CopyableMarkdownContent
       className="w-full px-3 py-3 mb-5 border border-border rounded-lg bg-slate-50 dark:bg-slate-900/50"
-      content={parsed.content}
+      content={convertNewlinesToBreaks(parsed.content)}
     />
   );
 };

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/resumeChat/ChatActionMenu.tsx
@@ -130,25 +130,32 @@ export const ChatActionMenu: FC<ChatActionMenuProps> = ({
           </Button>
         )}
         {sessionProcess && abortTask && (
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            onClick={() => {
-              abortTask.mutate(sessionProcess.id);
-            }}
-            disabled={abortTask.isPending || isPending}
-            className="h-7 px-2 gap-1.5 text-xs rounded-lg"
-          >
-            {abortTask.isPending ? (
-              <LoaderIcon className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <XIcon className="w-3.5 h-3.5" />
-            )}
-            <span>
-              <Trans id="session.conversation.abort" />
-            </span>
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={() => {
+                  abortTask.mutate(sessionProcess.id);
+                }}
+                disabled={abortTask.isPending || isPending}
+                className="h-7 px-2 gap-1.5 text-xs rounded-lg"
+              >
+                {abortTask.isPending ? (
+                  <LoaderIcon className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <XIcon className="w-3.5 h-3.5" />
+                )}
+                <span>
+                  <Trans id="session.conversation.abort" />
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <Trans id="session.conversation.abort" /> (Esc)
+            </TooltipContent>
+          </Tooltip>
         )}
 
         {enableCCOptions && onCCOptionsChange && (


### PR DESCRIPTION
## Summary

This PR improves the user message experience with two key enhancements:

1. **Newline rendering in user messages** - User messages with newlines now properly display line breaks. Previously, single `\n` characters in user messages were collapsed by the Markdown renderer, making multi-line messages appear on one line. Now we convert newlines to Markdown hard line breaks before rendering.

2. **Esc key to abort sessions** - Users can now press Escape to abort a running session as a keyboard shortcut. The abort button tooltip shows "(Esc)" as a hint. The shortcut respects focus boundaries and is inactive when input or textarea elements are focused.

## Test plan

- [x] All 947 unit tests pass
- [x] TypeScript type checks pass
- [x] Linter passes (oxlint)
- [x] Code formatting passes (oxfmt)
- [x] Translation catalogs synchronized
- [x] 6 new unit tests for newline conversion function
- [ ] CI Pass
- [ ] Manual verification:
  - [ ] User messages with multiple lines render with visible line breaks
  - [ ] Pressing Esc aborts an active session
  - [ ] Pressing Esc in an input field does not abort the session
  - [ ] Abort button shows "(Esc)" tooltip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Press Escape to quickly abort a running session when typing outside text fields
  * Abort button now displays a tooltip showing the Escape keyboard shortcut

* **Bug Fixes**
  * Single newlines in user messages now render as line breaks for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->