### PR TITLE
fix: support companion_intro attachment type in session logs

### DIFF
--- a/src/lib/conversation-schema/entry/AttachmentEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/AttachmentEntrySchema.test.ts
@@ -44,7 +44,7 @@ describe("AttachmentEntrySchema", () => {
       expect(result.success).toBe(true);
     });
 
-    test("rejects entry without addedLines", () => {
+    test("falls back to unknown schema when addedLines is missing", () => {
       const result = AttachmentEntrySchema.safeParse({
         ...baseFields,
         attachment: {
@@ -53,7 +53,8 @@ describe("AttachmentEntrySchema", () => {
           removedNames: [],
         },
       });
-      expect(result.success).toBe(false);
+      // Accepted by UnknownAttachmentSchema fallback
+      expect(result.success).toBe(true);
     });
   });
 
@@ -87,16 +88,56 @@ describe("AttachmentEntrySchema", () => {
       expect(result.success).toBe(true);
     });
 
-    test("rejects entry with wrong attachment type", () => {
+    test("rejects entry missing attachment type", () => {
       const result = AttachmentEntrySchema.safeParse({
         ...baseFields,
         attachment: {
-          type: "unknown_delta",
           addedNames: [],
           removedNames: [],
         },
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe("companion_intro", () => {
+    test("accepts valid entry", () => {
+      const result = AttachmentEntrySchema.safeParse({
+        ...baseFields,
+        attachment: {
+          type: "companion_intro",
+          name: "Crumb",
+          species: "owl",
+        },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.attachment.type).toBe("companion_intro");
+    });
+
+    test("falls back to unknown schema when name is missing", () => {
+      const result = AttachmentEntrySchema.safeParse({
+        ...baseFields,
+        attachment: {
+          type: "companion_intro",
+          species: "owl",
+        },
+      });
+      // Accepted by UnknownAttachmentSchema fallback
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("unknown attachment type (fallback)", () => {
+    test("accepts unknown attachment types gracefully", () => {
+      const result = AttachmentEntrySchema.safeParse({
+        ...baseFields,
+        attachment: {
+          type: "some_future_type",
+          someField: "value",
+        },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.attachment.type).toBe("some_future_type");
     });
   });
 });

--- a/src/lib/conversation-schema/entry/AttachmentEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/AttachmentEntrySchema.ts
@@ -25,9 +25,23 @@ const McpInstructionsDeltaSchema = AttachmentBaseEntrySchema.extend({
   }),
 });
 
+const CompanionIntroSchema = AttachmentBaseEntrySchema.extend({
+  attachment: z.object({
+    type: z.literal("companion_intro"),
+    name: z.string(),
+    species: z.string(),
+  }),
+});
+
+const UnknownAttachmentSchema = AttachmentBaseEntrySchema.extend({
+  attachment: z.looseObject({ type: z.string() }),
+});
+
 export const AttachmentEntrySchema = z.union([
   DeferredToolsDeltaSchema,
   McpInstructionsDeltaSchema,
+  CompanionIntroSchema,
+  UnknownAttachmentSchema,
 ]);
 
 export type AttachmentEntry = z.infer<typeof AttachmentEntrySchema>;


### PR DESCRIPTION
## Summary

- Add `CompanionIntroSchema` to handle `companion_intro` attachment entries from the Crumb companion feature (Claude Code v2.1.91+)
- Add `UnknownAttachmentSchema` fallback using `z.looseObject()` to gracefully handle future unknown attachment types instead of crashing
- Update tests to cover new schemas and fallback behavior

Closes #186

## Test plan

- [x] Existing `deferred_tools_delta` and `mcp_instructions_delta` tests still pass (backward compatibility)
- [x] New `companion_intro` entries parse successfully
- [x] Unknown future attachment types are accepted by the fallback schema
- [x] `pnpm gatecheck check` passes (typecheck, oxlint, oxfmt, vitest)
- [x] `./scripts/lingui-check.sh` passes

https://claude.ai/code/session_01UKmJRkW9atuJtLGdCQDgBZ