### PR TITLE
fix: require Node.js >=22.16.0 for StatementSync.setReturnArrays() support

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -52,7 +52,7 @@ Claude Code Viewer provides advanced control over Claude Code session processes:
 
 ### Requirements
 
-- **Node.js**: Version 20.19.0 or later (see [.node-version](../.node-version))
+- **Node.js**: Version 22.16.0 or later (see [.node-version](../.node-version))
 - **Package Manager**: pnpm 10.8.1 or later
 
 ### Initial Setup

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -52,7 +52,7 @@ Claude Code Viewer provides advanced control over Claude Code session processes:
 
 ### Requirements
 
-- **Node.js**: Version 22.16.0 or later (see [.node-version](../.node-version))
+- **Node.js**: Version 24.0.0 or later (see [.node-version](../.node-version))
 - **Package Manager**: pnpm 10.8.1 or later
 
 ### Initial Setup

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "workbox-window": "^7.4.0"
   },
   "engines": {
-    "node": ">=22.16.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "workbox-window": "^7.4.0"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.16.0"
   },
   "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
   "pnpm": {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import packageJson from "../../package.json" with { type: "json" };
 import type { CliOptions } from "./core/platform/services/CcvOptionsService.ts";
 import { checkDeprecatedEnvs } from "./core/platform/services/DeprecatedEnvDetector.ts";
+import { checkNodeVersion } from "./nodeVersionCheck.ts";
 import { startServer } from "./startServer.ts";
+
+checkNodeVersion();
 
 const program = new Command();
 

--- a/src/server/nodeVersionCheck.ts
+++ b/src/server/nodeVersionCheck.ts
@@ -1,0 +1,25 @@
+/**
+ * Checks that the current Node.js version satisfies the minimum requirement.
+ *
+ * drizzle-orm's node-sqlite adapter uses StatementSync.setReturnArrays(),
+ * which is only available in Node.js >=24.0.0 or >=22.16.0.
+ * Node.js v23.x does NOT have this API.
+ *
+ * @see https://nodejs.org/api/sqlite.html#statementsetreturnarraysenabled
+ */
+export const checkNodeVersion = (): void => {
+  const [majorStr, minorStr] = process.version.slice(1).split(".");
+  const major = Number(majorStr);
+  const minor = Number(minorStr);
+
+  const isSupported = (major === 22 && minor >= 16) || major >= 24;
+
+  if (!isSupported) {
+    process.stderr.write(
+      `Error: claude-code-viewer requires Node.js >=22.16.0 or >=24.0.0, but you are running ${process.version}.\n` +
+        `Node.js v23.x is not supported because it lacks the StatementSync.setReturnArrays() API.\n` +
+        `Please upgrade your Node.js version.\n`,
+    );
+    process.exit(1);
+  }
+};

--- a/src/server/nodeVersionCheck.ts
+++ b/src/server/nodeVersionCheck.ts
@@ -2,22 +2,17 @@
  * Checks that the current Node.js version satisfies the minimum requirement.
  *
  * drizzle-orm's node-sqlite adapter uses StatementSync.setReturnArrays(),
- * which is only available in Node.js >=24.0.0 or >=22.16.0.
- * Node.js v23.x does NOT have this API.
+ * which is only available in Node.js >=24.0.0.
  *
  * @see https://nodejs.org/api/sqlite.html#statementsetreturnarraysenabled
  */
 export const checkNodeVersion = (): void => {
-  const [majorStr, minorStr] = process.version.slice(1).split(".");
+  const majorStr = process.version.slice(1).split(".")[0];
   const major = Number(majorStr);
-  const minor = Number(minorStr);
 
-  const isSupported = (major === 22 && minor >= 16) || major >= 24;
-
-  if (!isSupported) {
+  if (major < 24) {
     process.stderr.write(
-      `Error: claude-code-viewer requires Node.js >=22.16.0 or >=24.0.0, but you are running ${process.version}.\n` +
-        `Node.js v23.x is not supported because it lacks the StatementSync.setReturnArrays() API.\n` +
+      `Error: claude-code-viewer requires Node.js >=24.0.0, but you are running ${process.version}.\n` +
         `Please upgrade your Node.js version.\n`,
     );
     process.exit(1);


### PR DESCRIPTION
## Summary\n\n- Update `engines` field in `package.json` from `>=22.13.0` to `>=22.16.0` to match the actual Node.js version required by `drizzle-orm`'s `node-sqlite` adapter (`StatementSync.setReturnArrays()` is available in v22.16.0+ and v24.0.0+)\n- Add a startup version check (`src/server/nodeVersionCheck.ts`) that prints a clear error message and exits if the Node.js version is unsupported (including v23.x which lacks the API)\n- Update `docs/dev.md` to reflect the correct minimum version\n\nCloses #185\n\n## Test plan\n\n- [ ] Verify `pnpm gatecheck check` passes\n- [ ] Verify the app starts normally on Node.js v24.x\n- [ ] Verify the app shows a clear error on Node.js v22.15.x or v23.x\n\nhttps://claude.ai/code/session_01UTew2H4chi1c9GwAqM5jKQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Node.js runtime requirement to 24.0.0+

* **Chores**
  * Updated package engine constraint to require Node.js 24.0.0 or higher
  * Added startup validation that aborts launch if the Node.js runtime is older than the required version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->