### PR TITLE
fix: file viewer fails for files in Claude project data directory

### DIFF
--- a/src/server/core/file-system/presentation/FileSystemController.ts
+++ b/src/server/core/file-system/presentation/FileSystemController.ts
@@ -91,7 +91,16 @@ const LayerImpl = Effect.gen(function* () {
 
       const { project } = yield* projectRepository.getProject(projectId);
 
-      if (project.meta.projectPath === null) {
+      // Allow reading files from either the source project directory or the Claude
+      // project data directory (e.g. ~/.claude/projects/.../memory/)
+      const claudeProjectPath = project.claudeProjectPath;
+      const sourceProjectPath = project.meta.projectPath;
+
+      const projectRoot = filePath.startsWith(`${claudeProjectPath}/`)
+        ? claudeProjectPath
+        : sourceProjectPath;
+
+      if (projectRoot === null) {
         return {
           response: {
             success: false,
@@ -103,9 +112,7 @@ const LayerImpl = Effect.gen(function* () {
         } as const satisfies ControllerResponse;
       }
 
-      const projectPath = project.meta.projectPath;
-
-      const result = yield* getFileContentEffect(projectPath, filePath).pipe(
+      const result = yield* getFileContentEffect(projectRoot, filePath).pipe(
         Effect.provideService(Path.Path, path),
         Effect.provideService(FileSystem.FileSystem, fs),
       );


### PR DESCRIPTION
Allow reading files from ~/.claude/projects/<project>/ (e.g. memory files) in addition to the source project directory.

Without this fix it's not possible to view files with "memories" which are stored in .claude directory and which are shown in the conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file path resolution to correctly determine the appropriate directory for reading files based on project configuration, ensuring files are accessed from the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->