### PR TITLE
fix: prevent duplicate first prompt in task modal for agent sessions

### DIFF
--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -309,7 +309,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        220
+        221
       ]
     ],
     "translation": "Failed to load task"
@@ -387,7 +387,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        212
+        213
       ]
     ],
     "translation": "Loading task..."
@@ -406,7 +406,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        198
+        199
       ]
     ],
     "translation": "{count} messages"
@@ -421,7 +421,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        236
+        237
       ]
     ],
     "translation": "No task data"
@@ -432,7 +432,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        239
+        240
       ]
     ],
     "translation": "No data is available for this task"
@@ -481,7 +481,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        229
+        230
       ]
     ],
     "translation": "Retry"
@@ -492,7 +492,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        189
+        190
       ]
     ],
     "translation": "Task ID"
@@ -514,7 +514,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        167
+        168
       ]
     ],
     "translation": "View Task Details"

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -309,7 +309,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        220
+        221
       ]
     ],
     "translation": "タスクの読み込みに失敗しました"
@@ -387,7 +387,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        212
+        213
       ]
     ],
     "translation": "タスクを読み込み中..."
@@ -406,7 +406,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        198
+        199
       ]
     ],
     "translation": "{count}件のメッセージ"
@@ -421,7 +421,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        236
+        237
       ]
     ],
     "translation": "タスクデータがありません"
@@ -432,7 +432,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        239
+        240
       ]
     ],
     "translation": "このタスクのデータは利用できません"
@@ -481,7 +481,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        229
+        230
       ]
     ],
     "translation": "再試行"
@@ -492,7 +492,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        189
+        190
       ]
     ],
     "translation": "タスクID"
@@ -514,7 +514,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        167
+        168
       ]
     ],
     "translation": "タスクを確認"

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -309,7 +309,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        220
+        221
       ]
     ],
     "translation": "加载任务失败"
@@ -387,7 +387,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        212
+        213
       ]
     ],
     "translation": "正在加载任务..."
@@ -406,7 +406,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        198
+        199
       ]
     ],
     "translation": "{count} 条消息"
@@ -421,7 +421,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        236
+        237
       ]
     ],
     "translation": "无任务数据"
@@ -432,7 +432,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        239
+        240
       ]
     ],
     "translation": "此任务的数据不可用"
@@ -481,7 +481,7 @@
       ],
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        229
+        230
       ]
     ],
     "translation": "重试"
@@ -492,7 +492,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        189
+        190
       ]
     ],
     "translation": "任务 ID"
@@ -514,7 +514,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx",
-        167
+        168
       ]
     ],
     "translation": "查看任务详情"

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/TaskModal.tsx
@@ -5,7 +5,6 @@ import { type FC, useRef, useState } from "react";
 import { z } from "zod";
 import type { SidechainConversation } from "@/lib/conversation-schema";
 import type { ToolResultContent } from "@/lib/conversation-schema/content/ToolResultContentSchema";
-import type { UserEntry } from "@/lib/conversation-schema/entry/UserEntrySchema";
 import { Badge } from "@/web/components/ui/badge";
 import { Button } from "@/web/components/ui/button";
 import {
@@ -17,6 +16,7 @@ import {
   DialogTrigger,
 } from "@/web/components/ui/dialog";
 import { agentSessionQuery } from "@/web/lib/api/queries";
+import { buildTaskModalConversations } from "./buildTaskModalConversations";
 import { ConversationList } from "./ConversationList";
 
 type TaskModalProps = {
@@ -126,12 +126,13 @@ export const TaskModal: FC<TaskModalProps> = ({
   });
 
   // Determine which data source to use
+  const apiConversations = data?.conversations ?? [];
   const conversations = hasLocalData
     ? localSidechainConversations.map((original) => ({
         ...original,
         isSidechain: false,
       }))
-    : (data?.conversations ?? []);
+    : apiConversations;
 
   const agentSessionId = hasLocalData ? undefined : data?.agentSessionId;
   const turnId = hasLocalData ? legacyConversation?.uuid : agentSessionId;
@@ -242,35 +243,22 @@ export const TaskModal: FC<TaskModalProps> = ({
           )}
           {showConversations && (
             <ConversationList
-              conversations={[
-                ...(hasLocalData
-                  ? []
-                  : [
-                      {
-                        type: "user",
-                        message: {
-                          role: "user",
-                          content: prompt,
-                        },
-                        isSidechain: false,
-                        userType: "external",
-                        cwd: firstConversation?.cwd ?? "dummy",
-                        sessionId: sessionId,
-                        version: firstConversation?.version ?? "dummy",
-                        uuid: "dummy",
-                        timestamp: firstConversation?.timestamp ?? "dummy",
-                        parentUuid: null,
-                        isMeta: false,
-                        toolUseResult: undefined,
-                        gitBranch: firstConversation?.gitBranch ?? "dummy",
-                        isCompactSummary: false,
-                      } satisfies UserEntry,
-                    ]),
-                ...conversations.map((c) => ({
-                  ...c,
-                  isSidechain: false,
-                })),
-              ]}
+              conversations={buildTaskModalConversations({
+                hasLocalData,
+                apiConversations,
+                conversations,
+                prompt,
+                sessionId,
+                firstConversationMeta:
+                  firstConversation !== undefined
+                    ? {
+                        cwd: firstConversation.cwd,
+                        version: firstConversation.version,
+                        timestamp: firstConversation.timestamp,
+                        gitBranch: firstConversation.gitBranch,
+                      }
+                    : undefined,
+              })}
               getToolResult={getToolResult}
               projectId={projectId}
               sessionId={sessionId}

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/buildTaskModalConversations.test.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/buildTaskModalConversations.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "vitest";
+import type { AssistantEntry } from "@/lib/conversation-schema/entry/AssistantEntrySchema";
+import type { UserEntry } from "@/lib/conversation-schema/entry/UserEntrySchema";
+import type { ExtendedConversation } from "@/server/core/types";
+import { buildTaskModalConversations } from "./buildTaskModalConversations";
+
+const makeUserEntry = (content: string, uuid: string): UserEntry => ({
+  type: "user",
+  message: { role: "user", content },
+  isSidechain: true,
+  userType: "external",
+  cwd: "/test",
+  sessionId: "test-session",
+  version: "1.0.0",
+  uuid,
+  timestamp: "2026-01-01T00:00:00Z",
+  parentUuid: null,
+  isMeta: false,
+  toolUseResult: undefined,
+  gitBranch: "main",
+  isCompactSummary: false,
+});
+
+const makeAssistantEntry = (text: string, uuid: string): AssistantEntry => ({
+  type: "assistant",
+  message: {
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    id: `msg_${uuid}`,
+    type: "message",
+    content: [{ type: "text", text }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  },
+  isSidechain: true,
+  userType: "external",
+  cwd: "/test",
+  sessionId: "test-session",
+  version: "1.0.0",
+  uuid,
+  timestamp: "2026-01-01T00:00:01Z",
+  parentUuid: null,
+  gitBranch: "main",
+});
+
+const meta = {
+  cwd: "/test",
+  version: "1.0.0",
+  timestamp: "2026-01-01T00:00:00Z",
+  gitBranch: "main",
+};
+
+describe("buildTaskModalConversations", () => {
+  const prompt = "Do something";
+
+  test("should NOT duplicate first user message when API data starts with user entry", () => {
+    const apiUserEntry = makeUserEntry(prompt, "real-uuid-1");
+    const apiAssistantEntry = makeAssistantEntry("OK", "real-uuid-2");
+    const apiConversations: ExtendedConversation[] = [apiUserEntry, apiAssistantEntry];
+
+    const result = buildTaskModalConversations({
+      hasLocalData: false,
+      apiConversations,
+      conversations: apiConversations,
+      prompt,
+      sessionId: "test-session",
+      firstConversationMeta: meta,
+    });
+
+    // The first user message should appear exactly once
+    const userMessages = result.filter((c) => c.type === "user");
+    expect(userMessages).toHaveLength(1);
+
+    // Total should be 2 (1 user + 1 assistant), not 3
+    expect(result).toHaveLength(2);
+  });
+
+  test("should prepend synthetic entry when API data does NOT start with user entry", () => {
+    const apiAssistantEntry = makeAssistantEntry("OK", "real-uuid-2");
+    const apiConversations: ExtendedConversation[] = [apiAssistantEntry];
+
+    const result = buildTaskModalConversations({
+      hasLocalData: false,
+      apiConversations,
+      conversations: apiConversations,
+      prompt,
+      sessionId: "test-session",
+      firstConversationMeta: meta,
+    });
+
+    // Should have synthetic user entry + assistant = 2
+    expect(result).toHaveLength(2);
+    expect(result[0]?.type).toBe("user");
+    expect(result[1]?.type).toBe("assistant");
+  });
+
+  test("should NOT prepend synthetic entry when using local sidechain data", () => {
+    const localConversations: ExtendedConversation[] = [
+      makeUserEntry(prompt, "local-uuid-1"),
+      makeAssistantEntry("OK", "local-uuid-2"),
+    ];
+
+    const result = buildTaskModalConversations({
+      hasLocalData: true,
+      apiConversations: [],
+      conversations: localConversations,
+      prompt,
+      sessionId: "test-session",
+      firstConversationMeta: meta,
+    });
+
+    expect(result).toHaveLength(2);
+    const userMessages = result.filter((c) => c.type === "user");
+    expect(userMessages).toHaveLength(1);
+  });
+
+  test("should set isSidechain to false on all output conversations", () => {
+    const apiUserEntry = makeUserEntry(prompt, "real-uuid-1");
+    const apiConversations: ExtendedConversation[] = [apiUserEntry];
+
+    const result = buildTaskModalConversations({
+      hasLocalData: false,
+      apiConversations,
+      conversations: apiConversations,
+      prompt,
+      sessionId: "test-session",
+      firstConversationMeta: meta,
+    });
+
+    const sidechainValues = result
+      .filter(
+        (conv): conv is Extract<typeof conv, { isSidechain: boolean }> => "isSidechain" in conv,
+      )
+      .map((conv) => conv.isSidechain);
+
+    expect(sidechainValues).toEqual([false]);
+  });
+});

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/buildTaskModalConversations.test.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/buildTaskModalConversations.test.ts
@@ -128,12 +128,6 @@ describe("buildTaskModalConversations", () => {
       firstConversationMeta: meta,
     });
 
-    const sidechainValues = result
-      .filter(
-        (conv): conv is Extract<typeof conv, { isSidechain: boolean }> => "isSidechain" in conv,
-      )
-      .map((conv) => conv.isSidechain);
-
-    expect(sidechainValues).toEqual([false]);
+    expect(result[0]).toMatchObject({ isSidechain: false });
   });
 });

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/buildTaskModalConversations.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/buildTaskModalConversations.ts
@@ -1,0 +1,71 @@
+import type { UserEntry } from "@/lib/conversation-schema/entry/UserEntrySchema";
+import type { ExtendedConversation } from "@/server/core/types";
+
+type ConversationMetadata = {
+  cwd: string;
+  version: string;
+  timestamp: string;
+  gitBranch?: string;
+};
+
+/**
+ * Build the conversation list for the TaskModal.
+ *
+ * When agent session data is fetched from the API (separate agent-*.jsonl files),
+ * the first entry is already the user's prompt. A synthetic user entry must NOT
+ * be prepended in that case, otherwise the prompt appears twice.
+ *
+ * A synthetic entry is only needed when the API returns conversations that do
+ * not start with a user message (legacy or edge cases).
+ */
+export const buildTaskModalConversations = (options: {
+  hasLocalData: boolean;
+  apiConversations: readonly ExtendedConversation[];
+  conversations: readonly ExtendedConversation[];
+  prompt: string;
+  sessionId: string;
+  firstConversationMeta: ConversationMetadata | undefined;
+}): ExtendedConversation[] => {
+  const {
+    hasLocalData,
+    apiConversations,
+    conversations,
+    prompt,
+    sessionId,
+    firstConversationMeta,
+  } = options;
+
+  const apiDataHasFirstUserMessage =
+    !hasLocalData && apiConversations.length > 0 && apiConversations[0]?.type === "user";
+
+  const syntheticEntry: UserEntry = {
+    type: "user",
+    message: {
+      role: "user",
+      content: prompt,
+    },
+    isSidechain: false,
+    userType: "external",
+    cwd: firstConversationMeta?.cwd ?? "dummy",
+    sessionId: sessionId,
+    version: firstConversationMeta?.version ?? "dummy",
+    uuid: "dummy",
+    timestamp: firstConversationMeta?.timestamp ?? "dummy",
+    parentUuid: null,
+    isMeta: false,
+    toolUseResult: undefined,
+    gitBranch: firstConversationMeta?.gitBranch ?? "dummy",
+    isCompactSummary: false,
+  };
+
+  const prefix: ExtendedConversation[] =
+    hasLocalData || apiDataHasFirstUserMessage ? [] : [syntheticEntry];
+
+  return [
+    ...prefix,
+    ...conversations.map((c) => ({
+      ...c,
+      isSidechain: false,
+    })),
+  ];
+};


### PR DESCRIPTION
## Summary

- Fix duplicate first user prompt when viewing agent/task session details via TaskModal
- Extract conversation-building logic into a pure testable function `buildTaskModalConversations`
- Add 4 unit tests covering the duplication bug and edge cases

## Root Cause

When `TaskModal` fetched agent session data via API (`!hasLocalData` path), it always prepended a synthetic `UserEntry` with the task prompt. However, `agent-*.jsonl` files already contain the first user message as entry[0], causing the prompt to render twice.

## Fix

Check whether `apiConversations[0]?.type === "user"` before prepending the synthetic entry. Skip it when the API data already starts with a user message.

## Test plan

- [x] Unit tests: RED with bug → GREEN with fix (4 tests)
- [x] All 955 existing tests pass
- [x] typecheck, oxlint, oxfmt, lingui-check all pass
- [ ] Manual: open a session with Agent tool calls → click "View Task Details" → first prompt should appear once

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved conversation-list construction by extracting conversation-building logic into a dedicated utility for clearer behavior and maintainability.

* **Tests**
  * Added tests covering API vs local conversation handling, synthetic user entry prepending, sequencing, and property normalization.

* **Chores**
  * Updated i18n metadata references (no translation text changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->