### PR TITLE
fix: use break-words instead of break-all on markdown paragraphs

### DIFF
--- a/src/web/app/components/MarkdownContent.tsx
+++ b/src/web/app/components/MarkdownContent.tsx
@@ -106,7 +106,7 @@ export const MarkdownContent: FC<MarkdownContentProps> = ({ content, className =
       },
       p({ children, ...props }) {
         return (
-          <p className="mb-4 leading-7 text-foreground break-all" {...props}>
+          <p className="mb-4 leading-7 text-foreground break-words" {...props}>
             {children}
           </p>
         );


### PR DESCRIPTION
## Summary

Fixes #198.

Replaces `break-all` with `break-words` on the markdown `<p>` renderer so English (and other Latin-script) prose no longer wraps mid-word.

## Why

Tailwind's `break-all` → CSS `word-break: break-all`, which permits line breaks between **any** two characters, ignoring word boundaries. That is acceptable for CJK text but incorrect for Latin/mixed prose: in narrow columns (e.g. when the right panel is open) words like `conversation` get split as `conversa` / `tion` across lines.

`break-words` → CSS `overflow-wrap: break-word` preserves word boundaries for normal prose while still breaking long unbreakable tokens (URLs, hashes, etc.) when they would otherwise overflow the container.

## Change

```diff
- <p className="mb-4 leading-7 text-foreground break-all" {...props}>
+ <p className="mb-4 leading-7 text-foreground break-words" {...props}>
```

Scoped deliberately to `MarkdownContent`'s `<p>` renderer. Other `break-all` usages in the codebase (e.g. on `<code>` / `<pre>` / terminal-style blocks) are left as-is because character-level breaks are appropriate there.

## Test plan

- [ ] Open a session with a long English assistant reply
- [ ] Open the right panel to narrow the conversation column
- [ ] Verify words wrap at spaces, not mid-letter
- [ ] Verify very long tokens (URLs, hashes) still wrap and don't overflow
- [ ] Verify CJK text (Japanese/Chinese sessions) still wraps correctly

## Notes

Happy to extend this to audit the other `break-all` usages listed in #198 in a follow-up PR if you'd like — I kept this one minimal and focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text breaking behavior in markdown content to wrap at word boundaries instead of breaking individual characters, improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->