### PR TITLE
docs: note 30-day session cleanup default and cleanupPeriodDays override

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ The application reads Claude Code conversation logs from:
 - **Format**: JSONL files containing conversation entries
 - **Auto-detection**: Automatically discovers new projects and sessions
 
+> [!NOTE]
+> **30 Day Session Cleanup Default:** Claude Code defaults to auto-delete all session transcripts older than 30 days. Claude Code Viewer does not make backups of your session files so when the `.jsonl` files get deleted those sessions will no longer exist in Claude Code Viewer. To override the 30 day retention default, add [`cleanupPeriodDays`](https://code.claude.com/docs/en/settings) with a number greater than 30 in `~/.claude/settings.json` and restart Claude Code.
+>
+> ```json
+> {
+>   "cleanupPeriodDays": 365
+> }
+> ```
+
 ## Internationalization (i18n)
 
 Claude Code Viewer currently supports **English**, **Japanese**, and **Simplified Chinese (简体中文)**. Adding new languages is straightforward—simply add a new `messages.json` file for your locale (see [src/i18n/locales/](./src/i18n/locales/) for examples).


### PR DESCRIPTION
## Summary
 
- Add a `[!NOTE]` callout under the Data Source section explaining that Claude Code auto-deletes session transcripts after 30 days by default unless you add a `cleanupPeriodDays` setting to `~/.claude/settings.json`.
- Include a copy-pasteable JSON snippet to override the retention period
- Link to the official Claude Code settings docs for full details 
 
## Context

> I was recently shocked when looking up some valuable session info on a project I've been working on for months. I had no idea that Claude Code automatically deletes my .jsonl files after 30 days.

Claude Code Viewer is a read-only viewer — it does not back up or cache the source `.jsonl` files. When Claude Code's startup cleanup deletes transcripts older than 30 days, those sessions silently disappear from CCV's UI with no indication of why.
 
This is a common point of confusion for users who return to CCV after a month and find their session history missing. The note in README surfaces the upstream behavior and gives users a one-line fix. 
 
Relevant upstream docs: 
- https://code.claude.com/docs/en/settings (`cleanupPeriodDays`) 
- https://code.claude.com/docs/en/claude-directory (cleanup behavior) 
 
## Test plan 
 
- [ ] Verify the `[!NOTE]` callout renders correctly on GitHub (blockquote + embedded JSON code block) 
- [ ] Confirm the `cleanupPeriodDays` link resolves to the correct Claude Code settings page
- [ ] No code changes — README only 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation about the automatic cleanup of session transcripts, which are deleted after 30 days by default. Clarified that Claude Code Viewer does not maintain backups and provided instructions on how to customize the retention period through configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->