### PR TITLE
fix: resolve migrations folder via fileURLToPath for Windows startup

### DIFF
--- a/src/server/lib/db/DrizzleService.ts
+++ b/src/server/lib/db/DrizzleService.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable no-restricted-imports */
-/* Exception: node:sqlite is required by drizzle node-sqlite driver. */
+/* Exception: node:sqlite is required by drizzle node-sqlite driver; node:url fileURLToPath is required for cross-platform file-URL-to-path conversion (URL.pathname produces "/C:/..." on Windows which fs APIs then resolve to "C:\\C:\\..."). */
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { FileSystem, Path } from "@effect/platform";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
@@ -8,7 +9,7 @@ import { Context, Effect, Layer } from "effect";
 import { ApplicationContext } from "../../core/platform/services/ApplicationContext.ts";
 import * as schema from "./schema.ts";
 
-const migrationsFolder = new URL("./migrations", import.meta.url).pathname;
+const migrationsFolder = fileURLToPath(new URL("./migrations", import.meta.url));
 const FTS5_DDL = `
   CREATE VIRTUAL TABLE IF NOT EXISTS session_messages_fts USING fts5(
     session_id UNINDEXED,

--- a/src/testing/layers/testDrizzleServiceLayer.ts
+++ b/src/testing/layers/testDrizzleServiceLayer.ts
@@ -1,13 +1,14 @@
 /* oxlint-disable no-restricted-imports */
 /* Exception: this test-only layer intentionally uses Node built-ins because migrating all DB tests to the new runtime abstraction at once is high-cost. Keep this exception scoped to this file only. */
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import { Layer } from "effect";
 import { type DrizzleDb, DrizzleService } from "../../server/lib/db/DrizzleService";
 import * as schema from "../../server/lib/db/schema";
 
-const migrationsFolder = new URL("../../server/lib/db/migrations", import.meta.url).pathname;
+const migrationsFolder = fileURLToPath(new URL("../../server/lib/db/migrations", import.meta.url));
 
 const FTS5_DDL = `
   CREATE VIRTUAL TABLE IF NOT EXISTS session_messages_fts USING fts5(


### PR DESCRIPTION
## Summary

On Windows, `new URL('./migrations', import.meta.url).pathname` produces a path of the form `/C:/Users/.../dist/migrations` (leading slash before the drive letter). When that string is passed to Node's `fs` APIs or joined via `path.resolve` against the process cwd, Windows normalizes it to `C:\C:\Users\...\dist\migrations` — a **doubled drive letter** — and drizzle's migration loader fails with `ENOENT: no such file or directory`, preventing the app from starting.

This is the exact error users see on first launch (Node 24, Windows 11, npx install):

```
[DrizzleService] Migration failed, recreating cache DB:
ENOENT: no such file or directory, scandir 'C:\C:\Users\i\AppData\Local\npm-cache\_npx\...\dist\migrations'
```

The fix is to use `fileURLToPath()` from `node:url`, which correctly converts a `file://` URL to a native platform path on all platforms (no-op shape on macOS/Linux, correctly strips the leading `/` on Windows).

## Changes

- `src/server/lib/db/DrizzleService.ts`: use `fileURLToPath(new URL(...))` for `migrationsFolder`
- `src/testing/layers/testDrizzleServiceLayer.ts`: same treatment in the test layer
- Extended the existing `/* Exception: ... */` comment on `DrizzleService.ts` to document the new `node:url` exception (alongside the pre-existing `node:sqlite` exception), since `CLAUDE.md` discourages raw `node:*` imports

## Verification

- `pnpm gatecheck check` → lint, format, typecheck all **pass** on this patch
- Built with `pnpm build`, ran `node dist/main.js --port 3400` on Windows 11 + Node 24.10 — starts cleanly, serves on `http://localhost:3400` without the `ENOENT` error
- Run before the patch (unpatched HEAD): reproduces the `C:\C:\` error consistently

## Scope notes

- This PR only addresses the migrations-folder path resolution. There are other pre-existing Windows issues (e.g. a set of test failures in `src/server/core/**` that encode Linux path separators; optional `@replit/ruspty-win32-x64-msvc` not shipping a Windows binary, disabling the in-app terminal panel). Those are out of scope here and also pre-date this change.
- The README currently says "Windows is not supported" — happy to revise scope/docs if you'd prefer, but this one-line fix seemed worth submitting on its own.

## Test plan

- [x] Lint / format / typecheck pass (`pnpm gatecheck check`)
- [x] Fresh build starts on Windows 11 + Node 24 and binds the configured port
- [ ] CI (Linux) on your end — expected to pass; please re-run if any flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration path resolution for better cross-platform compatibility, addressing path handling issues on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->