### PR TITLE
fix: support running on Windows

### DIFF
--- a/src/server/core/claude-code/models/ClaudeCode.test.ts
+++ b/src/server/core/claude-code/models/ClaudeCode.test.ts
@@ -101,7 +101,7 @@ describe("ClaudeCode.Config", () => {
               if (command._tag === "StandardCommand") {
                 shellModes.push(command.shell);
 
-                if (command.command === "which") {
+                if (command.command === "which" || command.command === "where") {
                   return Effect.succeed("/usr/local/bin/claude\n");
                 }
 

--- a/src/server/core/claude-code/models/ClaudeCode.ts
+++ b/src/server/core/claude-code/models/ClaudeCode.ts
@@ -9,8 +9,11 @@ type AgentSdkQuery = typeof agentSdk.query;
 type AgentSdkPrompt = Parameters<AgentSdkQuery>[0]["prompt"];
 type AgentSdkQueryOptions = NonNullable<Parameters<AgentSdkQuery>[0]["options"]>;
 
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const npxCacheRegExp = /_npx[/\\].*node_modules[\\/]\.bin/;
-const localNodeModulesBinRegExp = new RegExp(`${process.cwd()}/node_modules/.bin`);
+const localNodeModulesBinRegExp = new RegExp(
+  `${escapeRegExp(process.cwd())}[/\\\\]node_modules[/\\\\]\\.bin(?:[/\\\\]|$)`,
+);
 
 export const claudeCodePathPriority = (path: string): number => {
   if (npxCacheRegExp.test(path)) {

--- a/src/server/core/claude-code/models/ClaudeCode.ts
+++ b/src/server/core/claude-code/models/ClaudeCode.ts
@@ -44,8 +44,12 @@ const resolveClaudeCodePath = Effect.gen(function* () {
     return path.resolve(specifiedExecutablePath);
   }
 
-  // System PATH lookup
-  const claudePaths = yield* Command.string(Command.make("which", "-a", "claude")).pipe(
+  // System PATH lookup (`where` on Windows, `which -a` elsewhere — both list every match, one per line)
+  const lookupCommand =
+    process.platform === "win32"
+      ? Command.make("where", "claude")
+      : Command.make("which", "-a", "claude");
+  const claudePaths = yield* Command.string(lookupCommand).pipe(
     Effect.map(
       (output) =>
         output

--- a/src/server/core/file-system/functions/getFileContent.ts
+++ b/src/server/core/file-system/functions/getFileContent.ts
@@ -243,19 +243,21 @@ export const validateFilePath = (
   }
 
   const resolvedRoot = path.resolve(projectRoot);
-  let resolvedPath: string;
+  // path.isAbsolute correctly handles both POSIX (/foo) and Windows (C:\foo) absolute paths.
+  const resolvedPath = path.isAbsolute(filePath)
+    ? path.normalize(filePath)
+    : path.resolve(projectRoot, path.normalize(filePath));
 
-  // Handle absolute paths
-  if (filePath.startsWith("/")) {
-    resolvedPath = path.normalize(filePath);
-  } else {
-    // Handle relative paths
-    const normalizedPath = path.normalize(filePath);
-    resolvedPath = path.resolve(projectRoot, normalizedPath);
-  }
-
-  // Ensure the resolved path is within the project root
-  if (!resolvedPath.startsWith(`${resolvedRoot}/`) && resolvedPath !== resolvedRoot) {
+  // Containment check via path.relative — robust across separators and drive letters.
+  // Anything outside the root yields a result that either starts with ".." or is absolute
+  // (the latter happens on Windows when the two paths live on different drives).
+  const relativePath = path.relative(resolvedRoot, resolvedPath);
+  const escapesRoot =
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    relativePath.startsWith("../") || // tolerate POSIX-style separator just in case
+    path.isAbsolute(relativePath);
+  if (escapesRoot) {
     return { valid: false, message: "Path is outside the project root" };
   }
 

--- a/src/server/core/terminal/TerminalService.ts
+++ b/src/server/core/terminal/TerminalService.ts
@@ -76,20 +76,36 @@ const LayerImpl = Effect.gen(function* () {
     };
   };
 
-  const ruspty: RusptyModule | null = yield* Effect.tryPromise({
-    try: () => import("@replit/ruspty"),
-    catch: (error) => new Error(`Failed to load @replit/ruspty: ${String(error)}`),
-  }).pipe(
-    Effect.catchAll((error) =>
-      Effect.sync(() => {
-        Effect.runFork(Effect.logWarning(error.message));
-        return null;
-      }),
-    ),
-  );
+  // @replit/ruspty publishes prebuilt binaries only for darwin (x64/arm64) and linux-x64.
+  // On Windows there is no native module to load, so short-circuit instead of triggering
+  // a noisy MODULE_NOT_FOUND on every startup — terminal support is simply disabled.
+  const loadRuspty: Effect.Effect<RusptyModule | null> =
+    process.platform === "win32"
+      ? Effect.sync(() => {
+          Effect.runFork(
+            Effect.logInfo("@replit/ruspty has no Windows build; terminal support is disabled."),
+          );
+          return null;
+        })
+      : Effect.tryPromise({
+          try: () => import("@replit/ruspty"),
+          catch: (error) => new Error(`Failed to load @replit/ruspty: ${String(error)}`),
+        }).pipe(
+          Effect.catchAll((error) =>
+            Effect.sync(() => {
+              Effect.runFork(Effect.logWarning(error.message));
+              return null;
+            }),
+          ),
+        );
+  const ruspty = yield* loadRuspty;
 
   if (!ruspty) {
-    return disabledService("@replit/ruspty failed to load");
+    return disabledService(
+      process.platform === "win32"
+        ? "@replit/ruspty has no Windows build"
+        : "@replit/ruspty failed to load",
+    );
   }
 
   const trimBuffer = (session: TerminalSession) => {

--- a/src/server/lib/db/DrizzleService.ts
+++ b/src/server/lib/db/DrizzleService.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable no-restricted-imports */
 /* Exception: node:sqlite is required by drizzle node-sqlite driver. */
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { FileSystem, Path } from "@effect/platform";
 import { drizzle, type NodeSQLiteDatabase } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
@@ -8,7 +9,7 @@ import { Context, Effect, Layer } from "effect";
 import { ApplicationContext } from "../../core/platform/services/ApplicationContext.ts";
 import * as schema from "./schema.ts";
 
-const migrationsFolder = new URL("./migrations", import.meta.url).pathname;
+const migrationsFolder = fileURLToPath(new URL("./migrations", import.meta.url));
 const FTS5_DDL = `
   CREATE VIRTUAL TABLE IF NOT EXISTS session_messages_fts USING fts5(
     session_id UNINDEXED,

--- a/src/testing/layers/testDrizzleServiceLayer.ts
+++ b/src/testing/layers/testDrizzleServiceLayer.ts
@@ -1,13 +1,14 @@
 /* oxlint-disable no-restricted-imports */
 /* Exception: this test-only layer intentionally uses Node built-ins because migrating all DB tests to the new runtime abstraction at once is high-cost. Keep this exception scoped to this file only. */
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import { Layer } from "effect";
 import { type DrizzleDb, DrizzleService } from "../../server/lib/db/DrizzleService";
 import * as schema from "../../server/lib/db/schema";
 
-const migrationsFolder = new URL("../../server/lib/db/migrations", import.meta.url).pathname;
+const migrationsFolder = fileURLToPath(new URL("../../server/lib/db/migrations", import.meta.url));
 
 const FTS5_DDL = `
   CREATE VIRTUAL TABLE IF NOT EXISTS session_messages_fts USING fts5(


### PR DESCRIPTION
## Summary

Make the server start and run on Windows. Four independent issues were blocking it:

- **Drizzle migrations folder** (`src/server/lib/db/DrizzleService.ts`, `src/testing/layers/testDrizzleServiceLayer.ts`): `new URL('./migrations', import.meta.url).pathname` returns `/C:/...` on Windows, which `node-sqlite`'s migrator can't open. Switched to `fileURLToPath()` in both the runtime service and the test layer.
- **Claude executable lookup** (`src/server/core/claude-code/models/ClaudeCode.ts`): `which -a claude` doesn't exist on Windows. Use `where claude` when `process.platform === 'win32'`. Test mock (`ClaudeCode.test.ts`) updated to recognize both command names.
- **File path containment check** (`src/server/core/file-system/functions/getFileContent.ts`): the previous `resolvedPath.startsWith(`${resolvedRoot}/`)` check is POSIX-only and fails for backslashes / drive letters. Replaced with a `path.relative` based check that also handles cross-drive paths on Windows.
- **Terminal service** (`src/server/core/terminal/TerminalService.ts`): `@replit/ruspty` ships prebuilt binaries only for darwin (x64/arm64) and linux-x64. On Windows, short-circuit the dynamic import so the server doesn't log a confusing `MODULE_NOT_FOUND` on every boot. Terminal feature is disabled with a clear log message instead.

## Test plan

- [x] Static checks pass: `oxfmt`, `oxlint`, `typecheck`
- [x] Lingui translations complete (`./scripts/lingui-check.sh`)
- [x] Verified locally on Windows 11: server boots, project list loads, sessions render, file viewer works.
- [x] Verified delta on Windows: my changes reduce pre-existing Windows test failures (e.g. terminal/drizzle related). All static checks pass on the touched files.
- [ ] Should pass on the existing Linux/macOS CI without behavior change (path checks and exec lookup take the original branch on non-Windows platforms).

## Notes for reviewer

- All changes are guarded by `process.platform === 'win32'` or platform-agnostic primitives (`path.relative`, `path.isAbsolute`, `fileURLToPath`), so non-Windows behavior is preserved.
- I did not attempt to fix the broader pool of pre-existing Windows-only test failures (e.g. `ClaudeCodeController` tests that depend on POSIX path joining via template strings). Happy to follow up in a separate PR if desired.
- Commits are split per sub-issue for easier review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows executable discovery using platform-appropriate lookup.
  * Strengthened file path validation to reliably detect paths outside the project root.
  * Hardened terminal initialization on Windows to skip unsupported native terminals with clear messaging.

* **Tests**
  * Updated tests to recognize Windows-style command lookup for executables.

* **Chores**
  * Fixed migration path handling to reliably resolve filesystem paths for database migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->