### PR TITLE
fix: tolerate new system entry subtypes and lenient api_error shape

### DIFF
--- a/src/lib/conversation-schema/entry/SystemEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/SystemEntrySchema.ts
@@ -62,7 +62,25 @@ const CompactBoundaryEntrySchema = BaseEntrySchema.extend({
     .optional(),
 });
 
-// API error entry (tracks API errors and retries)
+// Away summary entry (Claude Code v2.1.112+ surfaces a recap when the user returns)
+const AwaySummaryEntrySchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
+  subtype: z.literal("away_summary"),
+  content: z.string(),
+});
+
+// Informational entry (occasional CLI-side notices, e.g. unknown skill args)
+const InformationalEntrySchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
+  subtype: z.literal("informational"),
+  content: z.string(),
+  level: z.enum(["info", "warning", "error"]).optional(),
+});
+
+// API error entry (tracks API errors and retries).
+// Field shapes vary across providers: Anthropic uses {type, message},
+// while some third-party gateways (e.g. Chinese rate-limit responses) use {code, message}.
+// Keep this lenient — surfacing the entry beats a hard schema reject.
 const ApiErrorEntrySchema = BaseEntrySchema.extend({
   type: z.literal("system"),
   subtype: z.literal("api_error"),
@@ -73,11 +91,13 @@ const ApiErrorEntrySchema = BaseEntrySchema.extend({
     requestID: z.string().nullable().optional(),
     error: z
       .object({
-        type: z.string(),
+        type: z.string().optional(),
+        code: z.string().optional(),
         error: z
           .object({
-            type: z.string(),
-            message: z.string(),
+            type: z.string().optional(),
+            code: z.string().optional(),
+            message: z.string().optional(),
           })
           .optional(),
         message: z.string().optional(),
@@ -95,6 +115,8 @@ export const SystemEntrySchema = z.union([
   TurnDurationEntrySchema,
   CompactBoundaryEntrySchema,
   ApiErrorEntrySchema,
+  AwaySummaryEntrySchema,
+  InformationalEntrySchema,
   SystemEntryWithContentSchema, // Must be last (catch-all for undefined subtype)
 ]);
 


### PR DESCRIPTION
## Summary

Make `SystemEntrySchema` accept three real-world entry shapes that the current schema rejects, so sessions containing them no longer fail to load:

- **`away_summary` subtype** — Claude Code v2.1.112+ surfaces a recap when the user returns from being idle. Added a dedicated schema for it.
- **`informational` subtype** — occasional CLI-side notices (e.g. unknown skill args). Added a schema with an optional `level` (`info | warning | error`).
- **`api_error` shape variance** — the current schema requires `error.type` and `error.error.{type,message}`. In practice some third-party gateways (notably Chinese rate-limit responses) return `{code, message}` instead of `{type}`. Made all of these fields optional. Surfacing the entry beats a hard schema reject — the UI already tolerates a thin payload here.

## Test plan

- [x] `oxfmt`, `oxlint`, `typecheck` pass on the changed file
- [x] `pnpm vitest run src/lib/conversation-schema/` — 86 tests pass
- [ ] Manually verified that previously-rejected sessions now parse cleanly

## Notes for reviewer

- All additions are additive in the `z.union([...])` and live before the `SystemEntryWithContentSchema` catch-all, so the union ordering is preserved.
- The `api_error` shape change only relaxes existing fields (makes them `.optional()`); no field is renamed or dropped, so existing logs continue to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for away status summary messages in system communications
  * Added support for informational system messages with optional severity levels

* **Improvements**
  * Enhanced error handling to accommodate more flexible error response formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->