### PR TITLE
fix: support AI-generated session titles

### DIFF
--- a/src/lib/conversation-schema/ConversationSchema.test.ts
+++ b/src/lib/conversation-schema/ConversationSchema.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, test } from "vitest";
 import { ConversationSchema } from "./index.ts";
 
 describe("ConversationSchema", () => {
+  test("accepts ai-title entries", () => {
+    const data = ConversationSchema.parse({
+      type: "ai-title",
+      aiTitle: "macro-dashboard のフォントと UI デザイン修正",
+      sessionId: "379ea227-4913-484f-9a55-fc76a9fc215f",
+    });
+
+    if (data.type !== "ai-title") {
+      throw new Error("Expected ai-title entry");
+    }
+    expect(data.aiTitle).toBe("macro-dashboard のフォントと UI デザイン修正");
+  });
+
   test("accepts away_summary system entries with entrypoint and slug", () => {
     const data = ConversationSchema.parse({
       parentUuid: "bde9c218-c40b-4d1c-9f2d-643d5fb22bc9",

--- a/src/lib/conversation-schema/entry/AiTitleEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/AiTitleEntrySchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const AiTitleEntrySchema = z.object({
+  type: z.literal("ai-title"),
+  aiTitle: z.string(),
+  sessionId: z.string(),
+});
+
+export type AiTitleEntry = z.infer<typeof AiTitleEntrySchema>;

--- a/src/lib/conversation-schema/index.ts
+++ b/src/lib/conversation-schema/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { AgentNameEntrySchema } from "./entry/AgentNameEntrySchema.ts";
 import { AgentSettingEntrySchema } from "./entry/AgentSettingEntrySchema.ts";
+import { AiTitleEntrySchema } from "./entry/AiTitleEntrySchema.ts";
 import { type AssistantEntry, AssistantEntrySchema } from "./entry/AssistantEntrySchema.ts";
 import { AttachmentEntrySchema } from "./entry/AttachmentEntrySchema.ts";
 import { CustomTitleEntrySchema } from "./entry/CustomTitleEntrySchema.ts";
@@ -23,6 +24,7 @@ export const ConversationSchema = z.union([
   QueueOperationEntrySchema,
   ProgressEntrySchema,
   CustomTitleEntrySchema,
+  AiTitleEntrySchema,
   AgentNameEntrySchema,
   AgentSettingEntrySchema,
   PermissionModeEntrySchema,

--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -1325,7 +1325,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        209
+        213
       ]
     ],
     "translation": "Raw Data: "
@@ -1336,7 +1336,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        202
+        206
       ]
     ],
     "translation": "Report This Issue"
@@ -1347,7 +1347,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        180
+        184
       ]
     ],
     "translation": "Schema Error"
@@ -1358,7 +1358,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        192
+        196
       ]
     ],
     "translation": "Schema Validation Error"
@@ -1369,7 +1369,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        195
+        199
       ]
     ],
     "translation": "Failed to parse this conversation entry. This may be due to format changes or parsing issues."

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -1325,7 +1325,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        209
+        213
       ]
     ],
     "translation": "生データ："
@@ -1336,7 +1336,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        202
+        206
       ]
     ],
     "translation": "この問題を報告"
@@ -1347,7 +1347,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        180
+        184
       ]
     ],
     "translation": "スキーマエラー"
@@ -1358,7 +1358,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        192
+        196
       ]
     ],
     "translation": "スキーマ検証エラー"
@@ -1369,7 +1369,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        195
+        199
       ]
     ],
     "translation": "この会話エントリの解析に失敗しました。フォーマットの変更または解析の問題が考えられます。"

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -1325,7 +1325,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        209
+        213
       ]
     ],
     "translation": "原始数据:"
@@ -1336,7 +1336,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        202
+        206
       ]
     ],
     "translation": "报告此问题"
@@ -1347,7 +1347,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        180
+        184
       ]
     ],
     "translation": "模式错误"
@@ -1358,7 +1358,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        192
+        196
       ]
     ],
     "translation": "模式验证错误"
@@ -1369,7 +1369,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx",
-        195
+        199
       ]
     ],
     "translation": "无法解析此对话条目。这可能是由于格式更改或解析问题。"

--- a/src/server/core/claude-code/functions/parseJsonl.test.ts
+++ b/src/server/core/claude-code/functions/parseJsonl.test.ts
@@ -5,6 +5,7 @@ import { parseJsonl } from "./parseJsonl.ts";
 type UserEntry = Extract<ExtendedConversation, { type: "user" }>;
 type SummaryEntry = Extract<ExtendedConversation, { type: "summary" }>;
 type CustomTitleEntry = Extract<ExtendedConversation, { type: "custom-title" }>;
+type AiTitleEntry = Extract<ExtendedConversation, { type: "ai-title" }>;
 type AgentNameEntry = Extract<ExtendedConversation, { type: "agent-name" }>;
 type PrLinkEntry = Extract<ExtendedConversation, { type: "pr-link" }>;
 type LastPromptEntry = Extract<ExtendedConversation, { type: "last-prompt" }>;
@@ -29,6 +30,14 @@ const expectCustomTitleEntry = (entry: ExtendedConversation | undefined): Custom
   expect(entry?.type).toBe("custom-title");
   if (entry?.type !== "custom-title") {
     throw new Error("Expected custom-title entry");
+  }
+  return entry;
+};
+
+const expectAiTitleEntry = (entry: ExtendedConversation | undefined): AiTitleEntry => {
+  expect(entry?.type).toBe("ai-title");
+  if (entry?.type !== "ai-title") {
+    throw new Error("Expected ai-title entry");
   }
   return entry;
 };
@@ -397,6 +406,22 @@ describe("parseJsonl", () => {
       const entry = expectCustomTitleEntry(result[0]);
       expect(entry.customTitle).toBe("My Custom Name");
       expect(entry.sessionId).toBe("abc-123");
+    });
+
+    it("ai-title entry parses correctly", () => {
+      const jsonl = JSON.stringify({
+        type: "ai-title",
+        aiTitle: "macro-dashboard のフォントと UI デザイン修正",
+        sessionId: "379ea227-4913-484f-9a55-fc76a9fc215f",
+      });
+
+      const result = parseJsonl(jsonl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty("type", "ai-title");
+      const entry = expectAiTitleEntry(result[0]);
+      expect(entry.aiTitle).toBe("macro-dashboard のフォントと UI デザイン修正");
+      expect(entry.sessionId).toBe("379ea227-4913-484f-9a55-fc76a9fc215f");
     });
 
     it("agent-name entry parses correctly", () => {

--- a/src/server/core/search/functions/extractSearchableText.test.ts
+++ b/src/server/core/search/functions/extractSearchableText.test.ts
@@ -126,6 +126,17 @@ describe("extractSearchableText", () => {
       expect(result).toBe("My Custom Session Name");
     });
 
+    it("returns aiTitle string for ai-title entries", () => {
+      const conversation: Conversation = {
+        type: "ai-title",
+        aiTitle: "AI Generated Session Name",
+        sessionId: "abc-123",
+      };
+
+      const result = extractSearchableText(conversation);
+      expect(result).toBe("AI Generated Session Name");
+    });
+
     it("returns null for agent-name entries", () => {
       const conversation: Conversation = {
         type: "agent-name",

--- a/src/server/core/search/functions/extractSearchableText.ts
+++ b/src/server/core/search/functions/extractSearchableText.ts
@@ -22,6 +22,10 @@ export const extractSearchableText = (conversation: ExtendedConversation): strin
     return conversation.customTitle;
   }
 
+  if (conversation.type === "ai-title") {
+    return conversation.aiTitle;
+  }
+
   if (conversation.type === "agent-name") {
     return null;
   }

--- a/src/server/core/session/functions/extractSessionTitle.test.ts
+++ b/src/server/core/session/functions/extractSessionTitle.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { ExtendedConversation } from "../../types.ts";
+import { extractSessionTitle } from "./extractSessionTitle.ts";
+
+describe("extractSessionTitle", () => {
+  it("uses ai-title entries as the session title", () => {
+    const conversations: ExtendedConversation[] = [
+      {
+        type: "ai-title",
+        aiTitle: "macro-dashboard のフォントと UI デザイン修正",
+        sessionId: "379ea227-4913-484f-9a55-fc76a9fc215f",
+      },
+    ];
+
+    expect(extractSessionTitle(conversations)).toBe("macro-dashboard のフォントと UI デザイン修正");
+  });
+
+  it("keeps user custom titles above ai-generated titles", () => {
+    const conversations: ExtendedConversation[] = [
+      {
+        type: "ai-title",
+        aiTitle: "AI generated title",
+        sessionId: "session-1",
+      },
+      {
+        type: "custom-title",
+        customTitle: "User renamed title",
+        sessionId: "session-1",
+      },
+    ];
+
+    expect(extractSessionTitle(conversations)).toBe("User renamed title");
+  });
+});

--- a/src/server/core/session/functions/extractSessionTitle.ts
+++ b/src/server/core/session/functions/extractSessionTitle.ts
@@ -1,0 +1,20 @@
+import type { ExtendedConversation } from "../../types.ts";
+
+export const extractSessionTitle = (
+  conversations: readonly ExtendedConversation[],
+): string | null => {
+  let aiTitle: string | null = null;
+  let customTitle: string | null = null;
+
+  for (const conversation of conversations) {
+    if (conversation.type === "custom-title") {
+      customTitle = conversation.customTitle;
+    }
+
+    if (conversation.type === "ai-title") {
+      aiTitle = conversation.aiTitle;
+    }
+  }
+
+  return customTitle ?? aiTitle;
+};

--- a/src/server/core/session/services/ExportService.ts
+++ b/src/server/core/session/services/ExportService.ts
@@ -382,6 +382,7 @@ const buildSidechainData = (conversations: Array<Conversation>): SidechainData =
       conv.type !== "queue-operation" &&
       conv.type !== "progress" &&
       conv.type !== "custom-title" &&
+      conv.type !== "ai-title" &&
       conv.type !== "agent-name" &&
       conv.type !== "agent-setting" &&
       conv.type !== "pr-link" &&
@@ -1016,6 +1017,7 @@ export const generateSessionHtml = (
         conv.type !== "queue-operation" &&
         conv.type !== "progress" &&
         conv.type !== "custom-title" &&
+        conv.type !== "ai-title" &&
         conv.type !== "agent-name" &&
         conv.type !== "agent-setting" &&
         conv.type !== "pr-link" &&

--- a/src/server/core/sync/services/SyncService.ts
+++ b/src/server/core/sync/services/SyncService.ts
@@ -9,6 +9,7 @@ import { ApplicationContext } from "../../platform/services/ApplicationContext.t
 import { decodeProjectId, encodeProjectId } from "../../project/functions/id.ts";
 import { extractSearchableText } from "../../search/functions/extractSearchableText.ts";
 import { aggregateTokenUsageAndCost } from "../../session/functions/aggregateTokenUsageAndCost.ts";
+import { extractSessionTitle } from "../../session/functions/extractSessionTitle.ts";
 import { getAgentSessionFilesForSession } from "../../session/functions/getAgentSessionFilesForSession.ts";
 import { decodeSessionId, encodeSessionId } from "../../session/functions/id.ts";
 import { isRegularSessionFile } from "../../session/functions/isRegularSessionFile.ts";
@@ -51,6 +52,8 @@ const extractActualSessionId = (content: string): string | undefined => {
 // directory, which is distinct from the Claude projects log directory.
 // ---------------------------------------------------------------------------
 
+const containsAiTitleEntry = (content: string): boolean => /"type"\s*:\s*"ai-title"/.test(content);
+
 const extractCwdFromContent = (content: string): string | null => {
   const lines = content.split("\n");
 
@@ -63,6 +66,7 @@ const extractCwdFromContent = (content: string): string | null => {
       conversation.type === "file-history-snapshot" ||
       conversation.type === "queue-operation" ||
       conversation.type === "custom-title" ||
+      conversation.type === "ai-title" ||
       conversation.type === "agent-name" ||
       conversation.type === "agent-setting" ||
       conversation.type === "pr-link" ||
@@ -181,17 +185,14 @@ const LayerImpl = Effect.gen(function* () {
         }
       }
 
-      // Extract custom title and PR links
-      let customTitle: string | null = null;
+      // Extract session title and PR links
+      const customTitle = extractSessionTitle(conversations);
       const prLinksMap = new Map<
         string,
         { prNumber: number; prUrl: string; prRepository: string }
       >();
 
       for (const conversation of conversations) {
-        if (conversation.type === "custom-title") {
-          customTitle = conversation.customTitle;
-        }
         if (conversation.type === "pr-link") {
           const key = `${conversation.prRepository}#${conversation.prNumber}`;
           prLinksMap.set(key, {
@@ -426,12 +427,18 @@ const LayerImpl = Effect.gen(function* () {
 
           const fileMtimeMs = Option.getOrElse(fileStat.mtime, () => new Date(0)).getTime();
 
-          // Check if new file or mtime changed
+          // Check if new file, mtime changed, or a previously synced file needs ai-title backfill
           const knownSession = knownSessions.find((s) => s.filePath === filePath);
           const isNew = !knownSessionPaths.has(filePath);
           const isModified = knownSession !== undefined && fileMtimeMs > knownSession.fileMtimeMs;
+          const needsAiTitleBackfill =
+            knownSession !== undefined &&
+            knownSession.customTitle === null &&
+            containsAiTitleEntry(
+              yield* fs.readFileString(filePath).pipe(Effect.catchAll(() => Effect.succeed(""))),
+            );
 
-          if (isNew || isModified) {
+          if (isNew || isModified || needsAiTitleBackfill) {
             const sessionId = encodeSessionId(filePath);
             yield* parseAndUpsertSession(projectId, sessionId, filePath, fileMtimeMs).pipe(
               Effect.catchAll((e) => {
@@ -504,8 +511,13 @@ const LayerImpl = Effect.gen(function* () {
         .get();
 
       if (stored !== undefined && fileMtimeMs <= stored.fileMtimeMs) {
-        // No changes
-        return;
+        const content = yield* fs
+          .readFileString(filePath)
+          .pipe(Effect.catchAll(() => Effect.succeed("")));
+        if (!containsAiTitleEntry(content)) {
+          // No changes
+          return;
+        }
       }
 
       yield* parseAndUpsertSession(projectId, sessionId, filePath, fileMtimeMs);

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx
@@ -109,6 +109,10 @@ const getSearchableText = (conversation: Conversation | ErrorJsonl): string => {
     return conversation.customTitle;
   }
 
+  if (conversation.type === "ai-title") {
+    return conversation.aiTitle;
+  }
+
   if (conversation.type === "last-prompt") {
     return conversation.lastPrompt;
   }
@@ -391,6 +395,7 @@ export const ConversationList: FC<ConversationListProps> = ({
 
       if (conv.type === "progress") return false;
       if (conv.type === "custom-title") return false;
+      if (conv.type === "ai-title") return false;
       if (conv.type === "agent-name") return false;
       if (conv.type === "agent-setting") return false;
       if (conv.type === "pr-link") return false;
@@ -631,6 +636,7 @@ export const ConversationList: FC<ConversationListProps> = ({
       conversation.type !== "queue-operation" &&
       conversation.type !== "progress" &&
       conversation.type !== "custom-title" &&
+      conversation.type !== "ai-title" &&
       conversation.type !== "agent-name" &&
       conversation.type !== "agent-setting" &&
       conversation.type !== "pr-link" &&

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.test.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.test.ts
@@ -57,16 +57,33 @@ describe("conversationRows", () => {
     const userConversation = createUserConversation("550e8400-e29b-41d4-a716-446655440001");
     const queueConversation = createQueueOperationConversation();
 
-    const rows = buildRenderableConversationRows([userConversation, queueConversation], () => true);
+    const aiTitleConversation: Conversation = {
+      type: "ai-title",
+      aiTitle: "AI title",
+      sessionId: "session-1",
+    };
 
-    expect(rows).toHaveLength(2);
+    const rows = buildRenderableConversationRows(
+      [userConversation, queueConversation, aiTitleConversation],
+      () => true,
+    );
+
+    expect(rows).toHaveLength(3);
     expect(rows[0]?.showTimestamp).toBe(true);
     expect(rows[1]?.showTimestamp).toBe(false);
+    expect(rows[2]?.showTimestamp).toBe(false);
   });
 
   it("generates stable keys for conversation entries", () => {
     const userConversation = createUserConversation("550e8400-e29b-41d4-a716-446655440002");
 
+    const aiTitleConversation: Conversation = {
+      type: "ai-title",
+      aiTitle: "AI title",
+      sessionId: "session-1",
+    };
+
     expect(getConversationKey(userConversation)).toBe("user_550e8400-e29b-41d4-a716-446655440002");
+    expect(getConversationKey(aiTitleConversation)).toBe("ai-title_session-1_AI title");
   });
 });

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.ts
@@ -13,6 +13,7 @@ const noTimestampConversationTypes = new Set<Conversation["type"]>([
   "queue-operation",
   "file-history-snapshot",
   "custom-title",
+  "ai-title",
   "agent-name",
   "agent-setting",
   "attachment",
@@ -49,6 +50,10 @@ export const getConversationKey = (conversation: Conversation) => {
 
   if (conversation.type === "custom-title") {
     return `custom-title_${conversation.sessionId}_${conversation.customTitle}`;
+  }
+
+  if (conversation.type === "ai-title") {
+    return `ai-title_${conversation.sessionId}_${conversation.aiTitle}`;
   }
 
   if (conversation.type === "agent-name") {

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/hooks/useSidechain.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/hooks/useSidechain.ts
@@ -16,6 +16,7 @@ export const useSidechain = (conversations: Conversation[]) => {
             conv.type !== "queue-operation" &&
             conv.type !== "progress" &&
             conv.type !== "custom-title" &&
+            conv.type !== "ai-title" &&
             conv.type !== "agent-name" &&
             conv.type !== "agent-setting" &&
             conv.type !== "pr-link" &&
@@ -110,6 +111,7 @@ export const useSidechain = (conversations: Conversation[]) => {
         conversation.type === "file-history-snapshot" ||
         conversation.type === "queue-operation" ||
         conversation.type === "custom-title" ||
+        conversation.type === "ai-title" ||
         conversation.type === "agent-name" ||
         conversation.type === "agent-setting" ||
         conversation.type === "pr-link" ||


### PR DESCRIPTION
## Summary
- Add schema support for Claude Code `ai-title` JSONL entries
- Use AI-generated titles for session display metadata when no user custom title exists
- Treat `ai-title` entries as metadata in rendering, search, sidechain, and export paths

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm fix`
- `pnpm gatecheck check`
- `./scripts/lingui-check.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for AI-generated session titles that serve as automatic fallback titles when custom titles aren't set.
  * AI-generated titles are now searchable within sessions.

* **Updates**
  * AI-generated title entries are excluded from the visible conversation list.
  * Custom titles take precedence over AI-generated titles when both exist for the same session.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-kimuson/claude-code-viewer/pull/207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->