### PR TITLE
fix: parse remote-control session log entries without validation errors

### DIFF
--- a/src/lib/conversation-schema/ConversationSchema.test.ts
+++ b/src/lib/conversation-schema/ConversationSchema.test.ts
@@ -160,4 +160,63 @@ describe("ConversationSchema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  test("accepts last-prompt entries with leafUuid (#210)", () => {
+    const data = ConversationSchema.parse({
+      type: "last-prompt",
+      leafUuid: "02e5eb93-f937-42d7-a944-d1b3eccdd414",
+      sessionId: "55aa54f1-c57b-476c-be3a-e9aac3b0aa72",
+    });
+    if (data.type !== "last-prompt") {
+      throw new Error("Expected last-prompt entry");
+    }
+    expect(data.leafUuid).toBe("02e5eb93-f937-42d7-a944-d1b3eccdd414");
+  });
+
+  test("accepts mode entries (#211)", () => {
+    const data = ConversationSchema.parse({
+      type: "mode",
+      mode: "normal",
+      sessionId: "3e3c611b-ebc9-42c2-a98a-344693a9a0d2",
+    });
+    if (data.type !== "mode") {
+      throw new Error("Expected mode entry");
+    }
+    expect(data.mode).toBe("normal");
+  });
+
+  test("accepts bridge-session entries (#212)", () => {
+    const data = ConversationSchema.parse({
+      type: "bridge-session",
+      sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+      bridgeSessionId: "cse_011C66zkyVAdqvuayh7XGpto",
+      lastSequenceNum: 0,
+    });
+    if (data.type !== "bridge-session") {
+      throw new Error("Expected bridge-session entry");
+    }
+    expect(data.bridgeSessionId).toBe("cse_011C66zkyVAdqvuayh7XGpto");
+  });
+
+  test("accepts bridge_status system entries (#213)", () => {
+    const result = ConversationSchema.safeParse({
+      parentUuid: null,
+      isSidechain: false,
+      type: "system",
+      subtype: "bridge_status",
+      content:
+        "/remote-control is active · Continue here, on your phone, or at https://claude.ai/code/session_0X0X0X0X0X0X0X0X0X0X0X0X",
+      url: "https://claude.ai/code/session_0X0X0X0X0X0X0X0X0X0X0X0X",
+      isMeta: false,
+      timestamp: "2026-05-29T11:31:46.015Z",
+      uuid: "bdc15df7-bf5a-4732-a51b-348e67975a2d",
+      userType: "external",
+      entrypoint: "cli",
+      cwd: "/Users/rymalia/projects/standup",
+      sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+      version: "2.1.156",
+      gitBranch: "main",
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/lib/conversation-schema/entry/BridgeSessionEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/BridgeSessionEntrySchema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { BridgeSessionEntrySchema } from "./BridgeSessionEntrySchema.ts";
+
+describe("BridgeSessionEntrySchema", () => {
+  test("accepts valid bridge-session entry", () => {
+    const result = BridgeSessionEntrySchema.safeParse({
+      type: "bridge-session",
+      sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+      bridgeSessionId: "cse_011C66zkyVAdqvuayh7XGpto",
+      lastSequenceNum: 0,
+    });
+    expect(result.success).toBe(true);
+    const data = result.success ? result.data : undefined;
+    expect(data?.type).toBe("bridge-session");
+    expect(data?.bridgeSessionId).toBe("cse_011C66zkyVAdqvuayh7XGpto");
+    expect(data?.lastSequenceNum).toBe(0);
+  });
+
+  test("accepts bridge-session entry without lastSequenceNum", () => {
+    const result = BridgeSessionEntrySchema.safeParse({
+      type: "bridge-session",
+      sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+      bridgeSessionId: "cse_011C66zkyVAdqvuayh7XGpto",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing bridgeSessionId", () => {
+    const result = BridgeSessionEntrySchema.safeParse({
+      type: "bridge-session",
+      sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects wrong type", () => {
+    const result = BridgeSessionEntrySchema.safeParse({
+      type: "mode",
+      sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+      bridgeSessionId: "cse_011C66zkyVAdqvuayh7XGpto",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/conversation-schema/entry/BridgeSessionEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/BridgeSessionEntrySchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+// "bridge-session" entries link a local session to a remote-control bridge
+// session (Claude Code v2.1.156+), enabling continuation on phone or web.
+export const BridgeSessionEntrySchema = z.object({
+  type: z.literal("bridge-session"),
+  sessionId: z.string(),
+  bridgeSessionId: z.string(),
+  lastSequenceNum: z.number().optional(),
+});
+
+export type BridgeSessionEntry = z.infer<typeof BridgeSessionEntrySchema>;

--- a/src/lib/conversation-schema/entry/LastPromptEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/LastPromptEntrySchema.test.ts
@@ -15,12 +15,16 @@ describe("LastPromptEntrySchema", () => {
     expect(data?.sessionId).toBe("28fc793f-fbe6-4062-8b4a-3d6e28f65b8b");
   });
 
-  test("rejects missing lastPrompt", () => {
+  test("accepts last-prompt entry with leafUuid instead of lastPrompt", () => {
     const result = LastPromptEntrySchema.safeParse({
       type: "last-prompt",
-      sessionId: "28fc793f-fbe6-4062-8b4a-3d6e28f65b8b",
+      leafUuid: "02e5eb93-f937-42d7-a944-d1b3eccdd414",
+      sessionId: "55aa54f1-c57b-476c-be3a-e9aac3b0aa72",
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    const data = result.success ? result.data : undefined;
+    expect(data?.leafUuid).toBe("02e5eb93-f937-42d7-a944-d1b3eccdd414");
+    expect(data?.lastPrompt).toBeUndefined();
   });
 
   test("rejects missing sessionId", () => {

--- a/src/lib/conversation-schema/entry/LastPromptEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/LastPromptEntrySchema.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
 
+// "last-prompt" entries track the most recent prompt for a session.
+// Older Claude Code versions emitted the prompt text via `lastPrompt`, while
+// newer versions (v2.1.145+, remote-control/bridge sessions) instead point at
+// the leaf message via `leafUuid`. Keep both optional for backward compatibility.
 export const LastPromptEntrySchema = z.object({
   type: z.literal("last-prompt"),
-  lastPrompt: z.string(),
+  lastPrompt: z.string().optional(),
+  leafUuid: z.string().optional(),
   sessionId: z.string(),
 });
 

--- a/src/lib/conversation-schema/entry/ModeEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/ModeEntrySchema.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { ModeEntrySchema } from "./ModeEntrySchema.ts";
+
+describe("ModeEntrySchema", () => {
+  test("accepts valid mode entry", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      mode: "normal",
+      sessionId: "3e3c611b-ebc9-42c2-a98a-344693a9a0d2",
+    });
+    expect(result.success).toBe(true);
+    const data = result.success ? result.data : undefined;
+    expect(data?.type).toBe("mode");
+    expect(data?.mode).toBe("normal");
+    expect(data?.sessionId).toBe("3e3c611b-ebc9-42c2-a98a-344693a9a0d2");
+  });
+
+  test("rejects missing mode", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      sessionId: "3e3c611b-ebc9-42c2-a98a-344693a9a0d2",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing sessionId", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      mode: "normal",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects wrong type", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "permission-mode",
+      mode: "normal",
+      sessionId: "3e3c611b-ebc9-42c2-a98a-344693a9a0d2",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/conversation-schema/entry/ModeEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/ModeEntrySchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+// "mode" entries record the active session mode (e.g. "normal").
+// Emitted by Claude Code v2.1.152+ alongside remote-control/bridge sessions.
+// Distinct from "permission-mode" entries, which carry a `permissionMode` field.
+export const ModeEntrySchema = z.object({
+  type: z.literal("mode"),
+  mode: z.string(),
+  sessionId: z.string(),
+});
+
+export type ModeEntry = z.infer<typeof ModeEntrySchema>;

--- a/src/lib/conversation-schema/entry/SystemEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/SystemEntrySchema.test.ts
@@ -56,4 +56,66 @@ describe("SystemEntrySchema", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe("bridge_status subtype", () => {
+    test("accepts valid bridge_status entry", () => {
+      const result = SystemEntrySchema.safeParse({
+        parentUuid: null,
+        isSidechain: false,
+        type: "system",
+        subtype: "bridge_status",
+        content:
+          "/remote-control is active · Continue here, on your phone, or at https://claude.ai/code/session_0X0X0X0X0X0X0X0X0X0X0X0X",
+        url: "https://claude.ai/code/session_0X0X0X0X0X0X0X0X0X0X0X0X",
+        isMeta: false,
+        timestamp: "2026-05-29T11:31:46.015Z",
+        uuid: "bdc15df7-bf5a-4732-a51b-348e67975a2d",
+        userType: "external",
+        entrypoint: "cli",
+        cwd: "/Users/rymalia/projects/standup",
+        sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+        version: "2.1.156",
+        gitBranch: "main",
+      });
+      expect(result.success).toBe(true);
+      const data = result.success ? result.data : undefined;
+      if (data?.type !== "system" || data.subtype !== "bridge_status") {
+        throw new Error("Expected bridge_status system entry");
+      }
+      expect(data.url).toBe("https://claude.ai/code/session_0X0X0X0X0X0X0X0X0X0X0X0X");
+    });
+
+    test("accepts bridge_status entry without url", () => {
+      const result = SystemEntrySchema.safeParse({
+        parentUuid: null,
+        isSidechain: false,
+        type: "system",
+        subtype: "bridge_status",
+        content: "/remote-control is active",
+        timestamp: "2026-05-29T11:31:46.015Z",
+        uuid: "bdc15df7-bf5a-4732-a51b-348e67975a2d",
+        userType: "external",
+        cwd: "/Users/rymalia/projects/standup",
+        sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+        version: "2.1.156",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test("rejects bridge_status entry without content", () => {
+      const result = SystemEntrySchema.safeParse({
+        parentUuid: null,
+        isSidechain: false,
+        type: "system",
+        subtype: "bridge_status",
+        timestamp: "2026-05-29T11:31:46.015Z",
+        uuid: "bdc15df7-bf5a-4732-a51b-348e67975a2d",
+        userType: "external",
+        cwd: "/Users/rymalia/projects/standup",
+        sessionId: "fc90d874-4741-4500-9462-a6255cfff0fe",
+        version: "2.1.156",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/src/lib/conversation-schema/entry/SystemEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/SystemEntrySchema.ts
@@ -77,6 +77,17 @@ const InformationalEntrySchema = BaseEntrySchema.extend({
   level: z.enum(["info", "warning", "error"]).optional(),
 });
 
+// Bridge status entry (Claude Code v2.1.156+ remote-control sessions).
+// Surfaced when /remote-control is active; carries a status message and the
+// claude.ai continuation URL.
+const BridgeStatusEntrySchema = BaseEntrySchema.extend({
+  type: z.literal("system"),
+  subtype: z.literal("bridge_status"),
+  content: z.string(),
+  url: z.string().optional(),
+  level: z.enum(["info", "warning", "error"]).optional(),
+});
+
 // API error entry (tracks API errors and retries).
 // Field shapes vary across providers: Anthropic uses {type, message},
 // while some third-party gateways (e.g. Chinese rate-limit responses) use {code, message}.
@@ -117,6 +128,7 @@ export const SystemEntrySchema = z.union([
   ApiErrorEntrySchema,
   AwaySummaryEntrySchema,
   InformationalEntrySchema,
+  BridgeStatusEntrySchema,
   SystemEntryWithContentSchema, // Must be last (catch-all for undefined subtype)
 ]);
 

--- a/src/lib/conversation-schema/index.ts
+++ b/src/lib/conversation-schema/index.ts
@@ -4,9 +4,11 @@ import { AgentSettingEntrySchema } from "./entry/AgentSettingEntrySchema.ts";
 import { AiTitleEntrySchema } from "./entry/AiTitleEntrySchema.ts";
 import { type AssistantEntry, AssistantEntrySchema } from "./entry/AssistantEntrySchema.ts";
 import { AttachmentEntrySchema } from "./entry/AttachmentEntrySchema.ts";
+import { BridgeSessionEntrySchema } from "./entry/BridgeSessionEntrySchema.ts";
 import { CustomTitleEntrySchema } from "./entry/CustomTitleEntrySchema.ts";
 import { FileHistorySnapshotEntrySchema } from "./entry/FileHIstorySnapshotEntrySchema.ts";
 import { LastPromptEntrySchema } from "./entry/LastPromptEntrySchema.ts";
+import { ModeEntrySchema } from "./entry/ModeEntrySchema.ts";
 import { PermissionModeEntrySchema } from "./entry/PermissionModeEntrySchema.ts";
 import { PrLinkEntrySchema } from "./entry/PrLinkEntrySchema.ts";
 import { ProgressEntrySchema } from "./entry/ProgressEntrySchema.ts";
@@ -28,8 +30,10 @@ export const ConversationSchema = z.union([
   AgentNameEntrySchema,
   AgentSettingEntrySchema,
   PermissionModeEntrySchema,
+  ModeEntrySchema,
   PrLinkEntrySchema,
   LastPromptEntrySchema,
+  BridgeSessionEntrySchema,
   AttachmentEntrySchema,
 ]);
 

--- a/src/server/core/session/services/ExportService.ts
+++ b/src/server/core/session/services/ExportService.ts
@@ -388,6 +388,8 @@ const buildSidechainData = (conversations: Array<Conversation>): SidechainData =
       conv.type !== "pr-link" &&
       conv.type !== "last-prompt" &&
       conv.type !== "permission-mode" &&
+      conv.type !== "mode" &&
+      conv.type !== "bridge-session" &&
       conv.isSidechain === true,
   ) as Array<Extract<Conversation, { type: "user" | "assistant" | "system" }>>;
 
@@ -1023,6 +1025,8 @@ export const generateSessionHtml = (
         conv.type !== "pr-link" &&
         conv.type !== "last-prompt" &&
         conv.type !== "permission-mode" &&
+        conv.type !== "mode" &&
+        conv.type !== "bridge-session" &&
         conv.isSidechain === true &&
         conv.agentId !== undefined
       ) {

--- a/src/server/core/sync/services/SyncService.ts
+++ b/src/server/core/sync/services/SyncService.ts
@@ -71,7 +71,9 @@ const extractCwdFromContent = (content: string): string | null => {
       conversation.type === "agent-setting" ||
       conversation.type === "pr-link" ||
       conversation.type === "last-prompt" ||
-      conversation.type === "permission-mode"
+      conversation.type === "permission-mode" ||
+      conversation.type === "mode" ||
+      conversation.type === "bridge-session"
     ) {
       continue;
     }

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx
@@ -114,7 +114,7 @@ const getSearchableText = (conversation: Conversation | ErrorJsonl): string => {
   }
 
   if (conversation.type === "last-prompt") {
-    return conversation.lastPrompt;
+    return conversation.lastPrompt ?? "";
   }
 
   return "";
@@ -401,6 +401,8 @@ export const ConversationList: FC<ConversationListProps> = ({
       if (conv.type === "pr-link") return false;
       if (conv.type === "last-prompt") return false;
       if (conv.type === "permission-mode") return false;
+      if (conv.type === "mode") return false;
+      if (conv.type === "bridge-session") return false;
 
       const isSidechain =
         conv.type !== "summary" &&
@@ -642,6 +644,8 @@ export const ConversationList: FC<ConversationListProps> = ({
       conversation.type !== "pr-link" &&
       conversation.type !== "last-prompt" &&
       conversation.type !== "permission-mode" &&
+      conversation.type !== "mode" &&
+      conversation.type !== "bridge-session" &&
       conversation.isSidechain;
 
     return (

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.ts
@@ -76,6 +76,14 @@ export const getConversationKey = (conversation: Conversation) => {
     return `permission-mode_${conversation.sessionId}_${conversation.permissionMode}`;
   }
 
+  if (conversation.type === "mode") {
+    return `mode_${conversation.sessionId}_${conversation.mode}`;
+  }
+
+  if (conversation.type === "bridge-session") {
+    return `bridge-session_${conversation.sessionId}_${conversation.bridgeSessionId}`;
+  }
+
   if (conversation.type === "attachment") {
     return `attachment_${conversation.uuid}`;
   }

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/hooks/useSidechain.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/hooks/useSidechain.ts
@@ -22,6 +22,8 @@ export const useSidechain = (conversations: Conversation[]) => {
             conv.type !== "pr-link" &&
             conv.type !== "last-prompt" &&
             conv.type !== "permission-mode" &&
+            conv.type !== "mode" &&
+            conv.type !== "bridge-session" &&
             conv.type !== "attachment",
         )
         .filter((conv) => conv.isSidechain === true),
@@ -117,6 +119,8 @@ export const useSidechain = (conversations: Conversation[]) => {
         conversation.type === "pr-link" ||
         conversation.type === "last-prompt" ||
         conversation.type === "permission-mode" ||
+        conversation.type === "mode" ||
+        conversation.type === "bridge-session" ||
         conversation.type === "attachment"
       ) {
         return false;


### PR DESCRIPTION
## Summary

Claude Code v2.1.145+ emits new session-log entries for its remote-control / bridge feature (continue a session on phone or web). Claude Code Viewer rejected these lines with schema validation errors. This adds/extends the Zod schemas and threads the two new metadata entry types through every consumer.

| Issue | Entry | Fix |
|-------|-------|-----|
| #210 | `last-prompt` with `leafUuid` | `lastPrompt` made optional, added optional `leafUuid` |
| #211 | `mode` (`{"type":"mode","mode":"normal"}`) | new `ModeEntrySchema` |
| #212 | `bridge-session` | new `BridgeSessionEntrySchema` |
| #213 | `system` / `subtype: "bridge_status"` | new variant before the catch-all |

`mode` and `bridge-session` are treated like sibling metadata entries (`permission-mode`, `last-prompt`) — filtered out of conversation rendering, sidechains, sync, and export. The `satisfies never` guard in `conversationRows.ts` and the `.cwd`/`.isSidechain` access sites made several of these edits type-forced.

## Testing

- Full suite: **980/980 pass** (schema dir 106/106); 4 e2e tests use the exact raw JSON from each issue, narrowing on `.type` to prove the intended union member matched.
- typecheck clean; oxlint + oxfmt clean.

Closes #210
Closes #211
Closes #212
Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new conversation entry types, including mode, bridge-session, and bridge status records.
  * Improved compatibility with newer and older last-prompt formats.

* **Bug Fixes**
  * Prevented these new entry types from breaking conversation lists, search, export, and session syncing.
  * Improved parsing so valid bridge-related records are accepted and displayed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->