### PR TITLE
fix: support mode entries in session logs

### DIFF
--- a/src/lib/conversation-schema/entry/ModeEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/ModeEntrySchema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { ModeEntrySchema } from "./ModeEntrySchema.ts";
+
+describe("ModeEntrySchema", () => {
+  test("accepts a mode entry emitted by newer Claude Code versions", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      mode: "normal",
+      sessionId: "9bb43739-21f2-45f2-bf3c-9270ba0dddca",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts arbitrary mode values", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      mode: "plan",
+      sessionId: "abc123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects entries with a different type", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "permission-mode",
+      mode: "normal",
+      sessionId: "abc123",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects entries missing sessionId", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      mode: "normal",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/conversation-schema/entry/ModeEntrySchema.test.ts
+++ b/src/lib/conversation-schema/entry/ModeEntrySchema.test.ts
@@ -36,4 +36,14 @@ describe("ModeEntrySchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("rejects entries with unknown extra fields", () => {
+    const result = ModeEntrySchema.safeParse({
+      type: "mode",
+      mode: "normal",
+      sessionId: "abc123",
+      unexpected: "field",
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/lib/conversation-schema/entry/ModeEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/ModeEntrySchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const ModeEntrySchema = z.object({
+  type: z.literal("mode"),
+  mode: z.string(),
+  sessionId: z.string(),
+});
+
+export type ModeEntry = z.infer<typeof ModeEntrySchema>;

--- a/src/lib/conversation-schema/entry/ModeEntrySchema.ts
+++ b/src/lib/conversation-schema/entry/ModeEntrySchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const ModeEntrySchema = z.object({
+export const ModeEntrySchema = z.strictObject({
   type: z.literal("mode"),
   mode: z.string(),
   sessionId: z.string(),

--- a/src/lib/conversation-schema/index.ts
+++ b/src/lib/conversation-schema/index.ts
@@ -7,6 +7,7 @@ import { AttachmentEntrySchema } from "./entry/AttachmentEntrySchema.ts";
 import { CustomTitleEntrySchema } from "./entry/CustomTitleEntrySchema.ts";
 import { FileHistorySnapshotEntrySchema } from "./entry/FileHIstorySnapshotEntrySchema.ts";
 import { LastPromptEntrySchema } from "./entry/LastPromptEntrySchema.ts";
+import { ModeEntrySchema } from "./entry/ModeEntrySchema.ts";
 import { PermissionModeEntrySchema } from "./entry/PermissionModeEntrySchema.ts";
 import { PrLinkEntrySchema } from "./entry/PrLinkEntrySchema.ts";
 import { ProgressEntrySchema } from "./entry/ProgressEntrySchema.ts";
@@ -27,6 +28,7 @@ export const ConversationSchema = z.union([
   AiTitleEntrySchema,
   AgentNameEntrySchema,
   AgentSettingEntrySchema,
+  ModeEntrySchema,
   PermissionModeEntrySchema,
   PrLinkEntrySchema,
   LastPromptEntrySchema,

--- a/src/server/core/session/services/ExportService.ts
+++ b/src/server/core/session/services/ExportService.ts
@@ -388,6 +388,7 @@ const buildSidechainData = (conversations: Array<Conversation>): SidechainData =
       conv.type !== "pr-link" &&
       conv.type !== "last-prompt" &&
       conv.type !== "permission-mode" &&
+      conv.type !== "mode" &&
       conv.isSidechain === true,
   ) as Array<Extract<Conversation, { type: "user" | "assistant" | "system" }>>;
 
@@ -1023,6 +1024,7 @@ export const generateSessionHtml = (
         conv.type !== "pr-link" &&
         conv.type !== "last-prompt" &&
         conv.type !== "permission-mode" &&
+        conv.type !== "mode" &&
         conv.isSidechain === true &&
         conv.agentId !== undefined
       ) {

--- a/src/server/core/sync/services/SyncService.ts
+++ b/src/server/core/sync/services/SyncService.ts
@@ -71,7 +71,8 @@ const extractCwdFromContent = (content: string): string | null => {
       conversation.type === "agent-setting" ||
       conversation.type === "pr-link" ||
       conversation.type === "last-prompt" ||
-      conversation.type === "permission-mode"
+      conversation.type === "permission-mode" ||
+      conversation.type === "mode"
     ) {
       continue;
     }

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationList.tsx
@@ -401,6 +401,7 @@ export const ConversationList: FC<ConversationListProps> = ({
       if (conv.type === "pr-link") return false;
       if (conv.type === "last-prompt") return false;
       if (conv.type === "permission-mode") return false;
+      if (conv.type === "mode") return false;
 
       const isSidechain =
         conv.type !== "summary" &&
@@ -642,6 +643,7 @@ export const ConversationList: FC<ConversationListProps> = ({
       conversation.type !== "pr-link" &&
       conversation.type !== "last-prompt" &&
       conversation.type !== "permission-mode" &&
+      conversation.type !== "mode" &&
       conversation.isSidechain;
 
     return (

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/conversationRows.ts
@@ -76,6 +76,10 @@ export const getConversationKey = (conversation: Conversation) => {
     return `permission-mode_${conversation.sessionId}_${conversation.permissionMode}`;
   }
 
+  if (conversation.type === "mode") {
+    return `mode_${conversation.sessionId}_${conversation.mode}`;
+  }
+
   if (conversation.type === "attachment") {
     return `attachment_${conversation.uuid}`;
   }

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/hooks/useSidechain.ts
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/hooks/useSidechain.ts
@@ -22,6 +22,7 @@ export const useSidechain = (conversations: Conversation[]) => {
             conv.type !== "pr-link" &&
             conv.type !== "last-prompt" &&
             conv.type !== "permission-mode" &&
+            conv.type !== "mode" &&
             conv.type !== "attachment",
         )
         .filter((conv) => conv.isSidechain === true),
@@ -117,6 +118,7 @@ export const useSidechain = (conversations: Conversation[]) => {
         conversation.type === "pr-link" ||
         conversation.type === "last-prompt" ||
         conversation.type === "permission-mode" ||
+        conversation.type === "mode" ||
         conversation.type === "attachment"
       ) {
         return false;


### PR DESCRIPTION
## Summary

- Add schema support for Claude Code `mode` JSONL entries (`{"type":"mode","mode":"normal","sessionId":"..."}`), distinct from the existing `permission-mode` entry (different type literal and field)
- The entry is emitted at least since v2.1.90 — the SDK version this project bundles — and appears in all my local session logs back to April 2026
- Without it, affected sessions render "Schema Error" rows, and sidechain/agent detection silently skips entries (on one real session the Agents panel showed 0 instead of 16)
- Treat `mode` entries as metadata in rendering, sidechain grouping, cwd resolution, and export paths (same handling as `permission-mode`)

## Verification

- `pnpm typecheck`
- `pnpm test`
- `pnpm fix`
- `pnpm gatecheck check`
- `./scripts/lingui-check.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing “mode” conversation entries as a first-class schema variant.
- **Bug Fixes**
  - Mode entries are no longer displayed as conversation rows and are excluded from sidechain classification.
  - Mode entries no longer affect working-directory detection or agent-session grouping.
- **Tests**
  - Added unit tests covering `mode` entry validation, including rejection of missing fields, wrong types, and unexpected extra fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->