### PR TITLE
Add MiniMax provider presets

### DIFF
--- a/src/lib/config/userConfig.ts
+++ b/src/lib/config/userConfig.ts
@@ -13,7 +13,10 @@ export const userConfigSchema = z.object({
   searchHotkey: z.enum(["ctrl-k", "command-k"]).optional().default("command-k"),
   findHotkey: z.enum(["ctrl-f", "command-f"]).optional().default("command-f"),
   autoScheduleContinueOnRateLimit: z.boolean().optional().default(false),
-  modelChoices: z.array(z.string()).optional().default(["default", "haiku", "sonnet", "opus"]),
+  modelChoices: z
+    .array(z.string())
+    .optional()
+    .default(["default", "haiku", "sonnet", "opus", "MiniMax-M3", "MiniMax-M2.7"]),
   usageMode: z.enum(["subscription", "api"]).optional(),
 });
 

--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -68,7 +68,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        205
+        206
       ]
     ],
     "translation": "Custom tool name"
@@ -124,7 +124,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        97
+        98
       ]
     ],
     "translation": "Key name"
@@ -253,7 +253,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        105
+        106
       ]
     ],
     "translation": "Value field"
@@ -1843,7 +1843,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        536
+        562
       ]
     ],
     "translation": "Example: 1.00"
@@ -1854,7 +1854,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        492
+        518
       ]
     ],
     "translation": "Example: 10"
@@ -1865,7 +1865,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        513
+        539
       ]
     ],
     "translation": "Example: 10000"
@@ -1876,7 +1876,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        424
+        450
       ]
     ],
     "translation": "Example: api.example.com, cdn.example.com"
@@ -3398,7 +3398,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        440
+        466
       ]
     ],
     "translation": "Advanced Settings"
@@ -3420,7 +3420,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        287
+        295
       ]
     ],
     "translation": "Disabled tools"
@@ -3431,7 +3431,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        130
+        131
       ]
     ],
     "translation": "Add environment variable"
@@ -3443,7 +3443,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        302
+        328
       ]
     ],
     "translation": "Environment Variables"
@@ -3668,7 +3668,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        526
+        552
       ]
     ],
     "translation": "Max Budget (USD)"
@@ -3680,7 +3680,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        504
+        530
       ]
     ],
     "translation": "Max Thinking Tokens"
@@ -3692,7 +3692,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        483
+        509
       ]
     ],
     "translation": "Max Turns"
@@ -3751,7 +3751,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        367
+        393
       ]
     ],
     "translation": "Allow unsandboxed commands"
@@ -3763,7 +3763,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        347
+        373
       ]
     ],
     "translation": "Auto-allow Bash if sandboxed"
@@ -3775,7 +3775,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        318
+        344
       ]
     ],
     "translation": "Sandbox"
@@ -3787,7 +3787,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        399
+        425
       ]
     ],
     "translation": "Allow local binding"
@@ -3799,7 +3799,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        408
+        434
       ]
     ],
     "translation": "Allowed Domains (comma-separated)"
@@ -3811,7 +3811,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        377
+        403
       ]
     ],
     "translation": "Network Settings"
@@ -3933,7 +3933,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        446
+        472
       ]
     ],
     "translation": "Setting Sources"
@@ -3945,7 +3945,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        276
+        284
       ]
     ],
     "translation": "Include Claude Code system prompt"
@@ -4023,7 +4023,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        579
+        605
       ],
       [
         "src/web/components/GlobalSidebar.tsx",

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -68,7 +68,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        205
+        206
       ]
     ],
     "translation": "カスタムツール名..."
@@ -124,7 +124,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        97
+        98
       ]
     ],
     "translation": "キー"
@@ -253,7 +253,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        105
+        106
       ]
     ],
     "translation": "値"
@@ -1843,7 +1843,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        536
+        562
       ]
     ],
     "translation": "例: 1.00"
@@ -1854,7 +1854,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        492
+        518
       ]
     ],
     "translation": "例: 10"
@@ -1865,7 +1865,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        513
+        539
       ]
     ],
     "translation": "例: 10000"
@@ -1876,7 +1876,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        424
+        450
       ]
     ],
     "translation": "例: api.example.com, cdn.example.com"
@@ -3398,7 +3398,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        440
+        466
       ]
     ],
     "translation": "詳細設定"
@@ -3420,7 +3420,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        287
+        295
       ]
     ],
     "translation": "無効化するツール"
@@ -3431,7 +3431,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        130
+        131
       ]
     ],
     "translation": "環境変数を追加"
@@ -3443,7 +3443,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        302
+        328
       ]
     ],
     "translation": "環境変数"
@@ -3668,7 +3668,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        526
+        552
       ]
     ],
     "translation": "最大予算 (USD)"
@@ -3680,7 +3680,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        504
+        530
       ]
     ],
     "translation": "最大思考トークン数"
@@ -3692,7 +3692,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        483
+        509
       ]
     ],
     "translation": "最大ターン数"
@@ -3751,7 +3751,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        367
+        393
       ]
     ],
     "translation": "サンドボックス外のコマンドを許可"
@@ -3763,7 +3763,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        347
+        373
       ]
     ],
     "translation": "サンドボックス化されている場合Bashを自動許可"
@@ -3775,7 +3775,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        318
+        344
       ]
     ],
     "translation": "サンドボックス"
@@ -3787,7 +3787,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        399
+        425
       ]
     ],
     "translation": "ローカルバインディングを許可"
@@ -3799,7 +3799,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        408
+        434
       ]
     ],
     "translation": "許可するドメイン (カンマ区切り)"
@@ -3811,7 +3811,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        377
+        403
       ]
     ],
     "translation": "ネットワーク設定"
@@ -3933,7 +3933,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        446
+        472
       ]
     ],
     "translation": "設定ソース"
@@ -3945,7 +3945,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        276
+        284
       ]
     ],
     "translation": "Claude Code のシステムプロンプトを含める"
@@ -4023,7 +4023,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        579
+        605
       ],
       [
         "src/web/components/GlobalSidebar.tsx",

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -68,7 +68,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        205
+        206
       ]
     ],
     "translation": "自定义工具名称..."
@@ -124,7 +124,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        97
+        98
       ]
     ],
     "translation": "键"
@@ -253,7 +253,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        105
+        106
       ]
     ],
     "translation": "值"
@@ -1843,7 +1843,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        536
+        562
       ]
     ],
     "translation": "例如: 1.00"
@@ -1854,7 +1854,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        492
+        518
       ]
     ],
     "translation": "例如: 10"
@@ -1865,7 +1865,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        513
+        539
       ]
     ],
     "translation": "例如: 10000"
@@ -1876,7 +1876,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        424
+        450
       ]
     ],
     "translation": "例如: api.example.com, cdn.example.com"
@@ -3398,7 +3398,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        440
+        466
       ]
     ],
     "translation": "高级设置"
@@ -3420,7 +3420,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        287
+        295
       ]
     ],
     "translation": "禁用的工具"
@@ -3431,7 +3431,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        130
+        131
       ]
     ],
     "translation": "添加环境变量"
@@ -3443,7 +3443,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        302
+        328
       ]
     ],
     "translation": "环境变量"
@@ -3668,7 +3668,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        526
+        552
       ]
     ],
     "translation": "最大预算 (USD)"
@@ -3680,7 +3680,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        504
+        530
       ]
     ],
     "translation": "最大思考令牌数"
@@ -3692,7 +3692,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        483
+        509
       ]
     ],
     "translation": "最大轮次"
@@ -3751,7 +3751,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        367
+        393
       ]
     ],
     "translation": "允许非沙盒命令"
@@ -3763,7 +3763,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        347
+        373
       ]
     ],
     "translation": "沙盒化时自动允许 Bash"
@@ -3775,7 +3775,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        318
+        344
       ]
     ],
     "translation": "沙盒"
@@ -3787,7 +3787,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        399
+        425
       ]
     ],
     "translation": "允许本地绑定"
@@ -3799,7 +3799,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        408
+        434
       ]
     ],
     "translation": "允许的域名 (逗号分隔)"
@@ -3811,7 +3811,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        377
+        403
       ]
     ],
     "translation": "网络设置"
@@ -3933,7 +3933,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        446
+        472
       ]
     ],
     "translation": "设置来源"
@@ -3945,7 +3945,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        276
+        284
       ]
     ],
     "translation": "包含 Claude Code 系统提示词"
@@ -4023,7 +4023,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx",
-        579
+        605
       ],
       [
         "src/web/components/GlobalSidebar.tsx",

--- a/src/server/core/platform/services/UserConfigService.ts
+++ b/src/server/core/platform/services/UserConfigService.ts
@@ -13,7 +13,7 @@ const LayerImpl = Effect.gen(function* () {
     searchHotkey: "command-k",
     findHotkey: "command-f",
     autoScheduleContinueOnRateLimit: false,
-    modelChoices: ["default", "haiku", "sonnet", "opus"],
+    modelChoices: ["default", "haiku", "sonnet", "opus", "MiniMax-M3", "MiniMax-M2.7"],
   });
 
   const setUserConfig = (newConfig: UserConfig) =>

--- a/src/testing/layers/testPlatformLayer.ts
+++ b/src/testing/layers/testPlatformLayer.ts
@@ -82,7 +82,14 @@ export const testPlatformLayer = (overrides?: {
         findHotkey: overrides?.userConfig?.findHotkey ?? "command-f",
         autoScheduleContinueOnRateLimit:
           overrides?.userConfig?.autoScheduleContinueOnRateLimit ?? false,
-        modelChoices: overrides?.userConfig?.modelChoices ?? ["default", "haiku", "sonnet", "opus"],
+        modelChoices: overrides?.userConfig?.modelChoices ?? [
+          "default",
+          "haiku",
+          "sonnet",
+          "opus",
+          "MiniMax-M3",
+          "MiniMax-M2.7",
+        ],
       }),
   });
 

--- a/src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx
+++ b/src/web/app/projects/[projectId]/components/chatForm/ClaudeCodeSettingsForm.tsx
@@ -16,6 +16,7 @@ import {
   transformFormToSchema,
   transformSchemaToForm,
 } from "./ccOptionsFormSchema";
+import { applyProviderPreset, providerPresets } from "./providerPresets";
 
 type ClaudeCodeSettingsFormProps = {
   value: CCOptionsSchema | undefined;
@@ -246,6 +247,13 @@ export const ClaudeCodeSettingsForm: FC<ClaudeCodeSettingsFormProps> = ({
   const transformed = useMemo(() => transformFormToSchema(formData), [formData]);
   const lastSerialized = useRef<string | null>(null);
 
+  const handleApplyProviderPreset = (preset: (typeof providerPresets)[number]) => {
+    const nextOptions = applyProviderPreset(transformed, preset);
+    const nextForm = transformSchemaToForm(nextOptions);
+    setValue("model", nextForm.model);
+    setValue("env", nextForm.env);
+  };
+
   // Sync form data to parent component
   useEffect(() => {
     const serialized = stableStringify(transformed);
@@ -298,6 +306,24 @@ export const ClaudeCodeSettingsForm: FC<ClaudeCodeSettingsFormProps> = ({
 
       {/* Environment Variables */}
       <div className="space-y-1.5">
+        <div className="space-y-2 rounded-md border border-border/50 bg-muted/20 p-2">
+          <Label className="text-xs font-medium">Provider Presets</Label>
+          <div className="flex flex-wrap gap-2">
+            {providerPresets.map((preset) => (
+              <Button
+                key={preset.id}
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => handleApplyProviderPreset(preset)}
+                disabled={disabled}
+                className="h-7 text-xs"
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </div>
+        </div>
         <Label className="text-xs font-medium">
           <Trans id="settings.env.label" message="Environment Variables" />
         </Label>

--- a/src/web/app/projects/[projectId]/components/chatForm/providerPresets.test.ts
+++ b/src/web/app/projects/[projectId]/components/chatForm/providerPresets.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import {
+  anthropicBaseUrlEnvName,
+  applyProviderPreset,
+  providerPresetConfig,
+  providerPresets,
+} from "./providerPresets";
+
+describe("providerPresets", () => {
+  test("includes the MiniMax text models and regional Anthropic endpoints", () => {
+    expect(providerPresetConfig.providerName).toBe("MiniMax");
+    expect(providerPresetConfig.defaultModel).toBe("MiniMax-M3");
+    expect(providerPresetConfig.models.map((model) => model.id)).toEqual([
+      "MiniMax-M3",
+      "MiniMax-M2.7",
+    ]);
+    expect(providerPresetConfig.models[0]).toMatchObject({
+      contextWindow: 1000000,
+      inputModalities: ["text", "image", "video"],
+      thinking: ["adaptive", "disabled"],
+      pricingUsdPerMillionTokens: { input: 0.6, output: 2.4, cache_read: 0.12 },
+    });
+    expect(providerPresetConfig.models[1]).toMatchObject({
+      contextWindow: 204800,
+      inputModalities: ["text"],
+      thinking: ["always_on"],
+      pricingUsdPerMillionTokens: {
+        input: 0.3,
+        output: 1.2,
+        cache_read: 0.06,
+        cache_write: 0.375,
+      },
+    });
+    expect(providerPresetConfig.endpoints.map((endpoint) => endpoint.anthropicBaseUrl)).toEqual([
+      "https://api.minimax.io/anthropic",
+      "https://api.minimaxi.com/anthropic",
+    ]);
+  });
+
+  test("applies the selected preset without discarding existing options", () => {
+    const chinaPreset = providerPresets.find((preset) => preset.id === "minimax-cn_zh");
+    expect(chinaPreset).toBeDefined();
+
+    if (chinaPreset === undefined) {
+      throw new Error("MiniMax China preset is missing");
+    }
+
+    const result = applyProviderPreset(
+      {
+        env: { EXISTING_FLAG: "1" },
+        maxTurns: 3,
+      },
+      chinaPreset,
+    );
+
+    expect(result).toEqual({
+      model: "MiniMax-M3",
+      env: {
+        EXISTING_FLAG: "1",
+        [anthropicBaseUrlEnvName]: "https://api.minimaxi.com/anthropic",
+      },
+      maxTurns: 3,
+    });
+  });
+});

--- a/src/web/app/projects/[projectId]/components/chatForm/providerPresets.ts
+++ b/src/web/app/projects/[projectId]/components/chatForm/providerPresets.ts
@@ -1,0 +1,76 @@
+import type { CCOptionsSchema } from "@/server/core/claude-code/schema";
+
+export const anthropicBaseUrlEnvName = "ANTHROPIC_BASE_URL";
+
+export const providerPresetConfig = {
+  providerName: "MiniMax",
+  defaultModel: "MiniMax-M3",
+  models: [
+    {
+      id: "MiniMax-M3",
+      contextWindow: 1000000,
+      pricingUsdPerMillionTokens: {
+        input: 0.6,
+        output: 2.4,
+        cache_read: 0.12,
+        cache_write: null,
+      },
+      inputModalities: ["text", "image", "video"],
+      thinking: ["adaptive", "disabled"],
+    },
+    {
+      id: "MiniMax-M2.7",
+      contextWindow: 204800,
+      pricingUsdPerMillionTokens: {
+        input: 0.3,
+        output: 1.2,
+        cache_read: 0.06,
+        cache_write: 0.375,
+      },
+      inputModalities: ["text"],
+      thinking: ["always_on"],
+    },
+  ],
+  endpoints: [
+    {
+      region: "global_en",
+      label: "Global",
+      anthropicBaseUrl: "https://api.minimax.io/anthropic",
+      openaiBaseUrl: "https://api.minimax.io/v1",
+      docsRoot: "https://platform.minimax.io/docs",
+    },
+    {
+      region: "cn_zh",
+      label: "China",
+      anthropicBaseUrl: "https://api.minimaxi.com/anthropic",
+      openaiBaseUrl: "https://api.minimaxi.com/v1",
+      docsRoot: "https://platform.minimaxi.com/docs",
+    },
+  ],
+} as const;
+
+export type ProviderPreset = {
+  id: string;
+  label: string;
+  model: string;
+  anthropicBaseUrl: string;
+};
+
+export const providerPresets: ProviderPreset[] = providerPresetConfig.endpoints.map((endpoint) => ({
+  id: `${providerPresetConfig.providerName.toLowerCase()}-${endpoint.region}`,
+  label: `${providerPresetConfig.providerName} ${endpoint.label}`,
+  model: providerPresetConfig.defaultModel,
+  anthropicBaseUrl: endpoint.anthropicBaseUrl,
+}));
+
+export const applyProviderPreset = (
+  options: CCOptionsSchema | undefined,
+  preset: ProviderPreset,
+): CCOptionsSchema => ({
+  ...options,
+  model: preset.model,
+  env: {
+    ...options?.env,
+    [anthropicBaseUrlEnvName]: preset.anthropicBaseUrl,
+  },
+});


### PR DESCRIPTION
Reason: Add MiniMax provider presets for Anthropic-compatible Claude Code sessions.

Changes:
- Add MiniMax provider preset data for the global and China Anthropic-compatible endpoints.
- Add MiniMax-M3 and MiniMax-M2.7 to default model choices.
- Add settings buttons that apply the selected MiniMax endpoint and default model while preserving existing options.

Checks:
- pnpm --dir "$REPO_DIR" install --frozen-lockfile --ignore-scripts
- pnpm --dir "$REPO_DIR" exec vitest --run "src/web/app/projects/[projectId]/components/chatForm/providerPresets.test.ts"
- pnpm --dir "$REPO_DIR" run lint:oxfmt
- pnpm --dir "$REPO_DIR" run lint:oxlint
- pnpm --dir "$REPO_DIR" run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax-M3 and MiniMax-M2.7 model options.
  * Added MiniMax provider presets for global and China endpoints.
  * Claude Code settings now offer preset buttons that automatically configure the model and endpoint while preserving existing environment settings.

* **Tests**
  * Added coverage for MiniMax model metadata, regional endpoints, and preset application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->