### PR TITLE
fix: prevent bottom controls from being clipped on mobile browsers

### DIFF
--- a/src/web/app/components/AppLayout.tsx
+++ b/src/web/app/components/AppLayout.tsx
@@ -51,7 +51,7 @@ export const AppLayout: FC<AppLayoutProps> = ({
   const [isSearchOpen, setIsSearchOpen] = useState(false);
 
   return (
-    <div className="flex flex-col h-screen w-screen overflow-hidden bg-background">
+    <div className="flex flex-col h-dvh w-screen overflow-hidden bg-background">
       {/* Top Status Bar */}
       <header className="h-(--spacing-header-height) flex items-center justify-between px-3 bg-muted/30 border-b border-border/40 text-xs flex-shrink-0 select-none">
         {/* Left: Project/Session Info */}

--- a/src/web/app/projects/page.tsx
+++ b/src/web/app/projects/page.tsx
@@ -13,7 +13,7 @@ export const ProjectsPage: FC = () => {
   const [isSystemInfoOpen, setIsSystemInfoOpen] = useState(false);
 
   return (
-    <div className="flex flex-col h-screen max-h-screen overflow-hidden">
+    <div className="flex flex-col h-dvh max-h-dvh overflow-hidden">
       <header className="h-(--spacing-header-height) flex items-center justify-between px-3 bg-muted/30 border-b border-border/40 text-xs flex-shrink-0 select-none">
         <span className="text-sm font-semibold text-foreground">claude-code-viewer</span>
         <div className="flex items-center gap-1">


### PR DESCRIPTION
Mobile Chrome/Firefox compute 100vh against the largest viewport (toolbar collapsed), so with overflow-hidden the app shell clipped whatever fell under the toolbar when it was visible, hiding the chat input's bottom control row. Use dvh units instead, which track the actual visible viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page sizing on mobile and responsive displays by using the browser’s dynamic viewport height.
  * Reduced layout issues caused by changing browser controls and viewport dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->