### PR TITLE
fix: parse SDK assistant entries without id or model

### DIFF
--- a/src/lib/conversation-schema/ConversationSchema.test.ts
+++ b/src/lib/conversation-schema/ConversationSchema.test.ts
@@ -102,6 +102,55 @@ describe("ConversationSchema", () => {
     expect(data.message.usage?.speed).toBe("standard");
   });
 
+  test("accepts SDK assistant entries without message id or model (#220)", () => {
+    const data = ConversationSchema.parse({
+      parentUuid: "3785b0af-9ee8-4c81-8be0-b22536200d48",
+      isSidechain: false,
+      message: {
+        type: "message",
+        usage: {
+          input_tokens: 29115,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 25216,
+          output_tokens: 1837,
+          server_tool_use: {
+            web_search_requests: 0,
+            web_fetch_requests: 0,
+          },
+          service_tier: "standard",
+          cache_creation: {
+            ephemeral_1h_input_tokens: 0,
+            ephemeral_5m_input_tokens: 0,
+          },
+          inference_geo: "",
+          iterations: [],
+          speed: "standard",
+        },
+        role: "assistant",
+        content: [{ type: "text", text: "Read PROJECT_PLAN.md." }],
+        stop_reason: "end_turn",
+      },
+      requestId: "4cfc9f6c79970235d817b63af8e3a96b",
+      type: "assistant",
+      uuid: "913c40ea-a25c-4a3d-8276-0512be23fb93",
+      timestamp: "2026-07-20T07:13:33.729Z",
+      userType: "external",
+      entrypoint: "sdk-ts",
+      cwd: "/home/dji/projects/ai_c/mlvm",
+      sessionId: "0cd2f20c-b786-49c9-aff6-75f4408a0d5f",
+      version: "2.1.97",
+      gitBranch: "HEAD",
+      slug: "binary-jingling-prism",
+    });
+
+    if (data.type !== "assistant") {
+      throw new Error("Expected assistant entry");
+    }
+    expect(data.message.id).toBeUndefined();
+    expect(data.message.model).toBeUndefined();
+    expect(data.message.content[0]?.type).toBe("text");
+  });
+
   test("accepts compact file reference attachments", () => {
     const result = ConversationSchema.safeParse({
       parentUuid: "8e7b736e-08dc-477c-b515-0bc9cf2df8fb",

--- a/src/lib/conversation-schema/message/AssistantMessageSchema.ts
+++ b/src/lib/conversation-schema/message/AssistantMessageSchema.ts
@@ -14,11 +14,11 @@ const AssistantMessageContentSchema = z.union([
 export type AssistantMessageContent = z.infer<typeof AssistantMessageContentSchema>;
 
 export const AssistantMessageSchema = z.object({
-  id: z.string(),
+  id: z.string().optional(),
   container: z.null().optional(),
   type: z.literal("message"),
   role: z.literal("assistant"),
-  model: z.string(),
+  model: z.string().optional(),
   content: z.array(AssistantMessageContentSchema),
   stop_reason: z.string().nullable().optional(),
   stop_sequence: z.string().nullable().optional(),

--- a/src/server/core/claude-code/functions/parseJsonl.test.ts
+++ b/src/server/core/claude-code/functions/parseJsonl.test.ts
@@ -3,6 +3,7 @@ import type { ErrorJsonl, ExtendedConversation } from "../../types.ts";
 import { parseJsonl } from "./parseJsonl.ts";
 
 type UserEntry = Extract<ExtendedConversation, { type: "user" }>;
+type AssistantEntry = Extract<ExtendedConversation, { type: "assistant" }>;
 type SummaryEntry = Extract<ExtendedConversation, { type: "summary" }>;
 type CustomTitleEntry = Extract<ExtendedConversation, { type: "custom-title" }>;
 type AiTitleEntry = Extract<ExtendedConversation, { type: "ai-title" }>;
@@ -14,6 +15,14 @@ const expectUserEntry = (entry: ExtendedConversation | undefined): UserEntry => 
   expect(entry?.type).toBe("user");
   if (entry?.type !== "user") {
     throw new Error("Expected user entry");
+  }
+  return entry;
+};
+
+const expectAssistantEntry = (entry: ExtendedConversation | undefined): AssistantEntry => {
+  expect(entry?.type).toBe("assistant");
+  if (entry?.type !== "assistant") {
+    throw new Error("Expected assistant entry");
   }
   return entry;
 };
@@ -96,6 +105,35 @@ describe("parseJsonl", () => {
       expect(result[0]).toHaveProperty("type", "user");
       const entry = expectUserEntry(result[0]);
       expect(entry.message.content).toBe("Hello");
+    });
+
+    it("message idとmodelがないSDK Assistantエントリをパースできる (#220)", () => {
+      const jsonl = JSON.stringify({
+        type: "assistant",
+        uuid: "913c40ea-a25c-4a3d-8276-0512be23fb93",
+        timestamp: "2026-07-20T07:13:33.729Z",
+        message: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "Read PROJECT_PLAN.md." }],
+          usage: { input_tokens: 29115, output_tokens: 1837 },
+          stop_reason: "end_turn",
+        },
+        isSidechain: false,
+        userType: "external",
+        entrypoint: "sdk-ts",
+        cwd: "/test",
+        sessionId: "test-session",
+        version: "2.1.97",
+        parentUuid: "3785b0af-9ee8-4c81-8be0-b22536200d48",
+      });
+
+      const result = parseJsonl(jsonl);
+
+      expect(result).toHaveLength(1);
+      const entry = expectAssistantEntry(result[0]);
+      expect(entry.message.id).toBeUndefined();
+      expect(entry.message.model).toBeUndefined();
     });
 
     it("単一のSummaryエントリをパースできる", () => {

--- a/src/server/core/session/functions/aggregateTokenUsageAndCost.test.ts
+++ b/src/server/core/session/functions/aggregateTokenUsageAndCost.test.ts
@@ -25,7 +25,7 @@ describe("aggregateTokenUsageAndCost", () => {
 
       expect(result.totalUsage.input_tokens).toBe(29115);
       expect(result.totalUsage.output_tokens).toBe(1837);
-      expect(result.totalCost.totalUsd).toBeGreaterThan(0);
+      expect(result.totalCost.totalUsd).toBeCloseTo(0.1149, 6);
       expect(result.modelName).toBe("claude-3.5-sonnet");
     });
 

--- a/src/server/core/session/functions/aggregateTokenUsageAndCost.test.ts
+++ b/src/server/core/session/functions/aggregateTokenUsageAndCost.test.ts
@@ -17,6 +17,29 @@ describe("aggregateTokenUsageAndCost", () => {
       expect(result.modelName).toBe("claude-3-5-sonnet-20240620");
     });
 
+    test("uses default pricing when an assistant message omits its model", () => {
+      const content =
+        '{"type":"assistant","uuid":"913c40ea-a25c-4a3d-8276-0512be23fb93","timestamp":"2026-07-20T07:13:33.729Z","isSidechain":false,"userType":"external","cwd":"/test","sessionId":"test-session","version":"2.1.97","parentUuid":"3785b0af-9ee8-4c81-8be0-b22536200d48","message":{"type":"message","role":"assistant","content":[],"usage":{"input_tokens":29115,"output_tokens":1837},"stop_reason":"end_turn"}}';
+
+      const result = aggregateTokenUsageAndCost([content]);
+
+      expect(result.totalUsage.input_tokens).toBe(29115);
+      expect(result.totalUsage.output_tokens).toBe(1837);
+      expect(result.totalCost.totalUsd).toBeGreaterThan(0);
+      expect(result.modelName).toBe("claude-3.5-sonnet");
+    });
+
+    test("inherits the last known model when a later assistant message omits it", () => {
+      const content =
+        '{"type":"assistant","uuid":"550e8400-e29b-41d4-a716-446655440001","timestamp":"2024-01-01T00:00:01.000Z","isSidechain":false,"userType":"external","cwd":"/test","sessionId":"test-session","version":"1.0.0","parentUuid":null,"message":{"type":"message","role":"assistant","model":"claude-3-opus-20240229","content":[],"usage":{"input_tokens":1000000,"output_tokens":1000000}}}\n' +
+        '{"type":"assistant","uuid":"550e8400-e29b-41d4-a716-446655440002","timestamp":"2024-01-01T00:00:02.000Z","isSidechain":false,"userType":"external","cwd":"/test","sessionId":"test-session","version":"1.0.0","parentUuid":"550e8400-e29b-41d4-a716-446655440001","message":{"type":"message","role":"assistant","content":[],"usage":{"input_tokens":1000000,"output_tokens":1000000}}}';
+
+      const result = aggregateTokenUsageAndCost([content]);
+
+      expect(result.totalCost.totalUsd).toBeCloseTo(180, 2);
+      expect(result.modelName).toBe("claude-3-opus-20240229");
+    });
+
     test("handles multiple assistant messages in single file", () => {
       const content =
         '{"type":"assistant","uuid":"550e8400-e29b-41d4-a716-446655440001","timestamp":"2024-01-01T00:00:01.000Z","isSidechain":false,"userType":"external","cwd":"/test","sessionId":"test-session","version":"1.0.0","parentUuid":"550e8400-e29b-41d4-a716-446655440000","message":{"type":"message","role":"assistant","model":"claude-3-5-sonnet-20240620","content":[],"usage":{"input_tokens":500,"output_tokens":250,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"stop_reason":null,"stop_sequence":null,"id":"msg_01"}}\n' +

--- a/src/server/core/session/functions/aggregateTokenUsageAndCost.ts
+++ b/src/server/core/session/functions/aggregateTokenUsageAndCost.ts
@@ -51,7 +51,7 @@ export const aggregateTokenUsageAndCost = (
         const outputTokens = messageUsage?.output_tokens ?? entryUsage?.output_tokens ?? 0;
         const cacheCreationInputTokens = messageUsage?.cache_creation_input_tokens ?? 0;
         const cacheReadInputTokens = messageUsage?.cache_read_input_tokens ?? 0;
-        const modelName = conversation.message.model;
+        const modelName = conversation.message.model ?? lastModelName;
 
         // Calculate cost for this specific message
         const messageCost = calculateTokenCost(


### PR DESCRIPTION
## Summary

- accept SDK-generated assistant messages that omit `message.id` and `message.model`
- preserve token and cost aggregation with the last known model, falling back to the existing default when none is available
- add schema, JSONL parser, and cost aggregation regressions for the exact shape reported in #220

## Safety review

- no dependency, lockfile, workflow, script, external communication, or command-execution changes
- no new XSS/injection path; the optional fields are not rendered directly
- `message.id` has no runtime consumers, and the sole `message.model` consumer now handles absence explicitly

## Verification

- `pnpm gatecheck check`
- `./scripts/lingui-check.sh`
- `mise x node@24.14.1 -- pnpm test` (106 files, 984 tests)
- exact JSON from #220 parses as an `assistant` entry

Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of assistant messages that omit message IDs or model information.
  * Preserved usage metadata and assistant content when optional fields are missing.
  * Applied sensible default or previously detected model pricing to maintain accurate token and cost calculations.
  * Maintained reliable conversation parsing when optional assistant message details are unavailable.

* **Tests**
  * Added coverage for parsing incomplete assistant entries and aggregating token usage and costs.
  * Verified model inheritance and fallback pricing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->