### PR TITLE
fix: render ANSI intensity in local command output

### DIFF
--- a/src/lib/ansi/parseAnsiIntensity.test.ts
+++ b/src/lib/ansi/parseAnsiIntensity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { parseAnsiIntensity, stripAnsiSgr } from "./parseAnsiIntensity";
+
+describe("parseAnsiIntensity", () => {
+  test("renders bold and dim ranges from ANSI SGR sequences", () => {
+    expect(
+      parseAnsiIntensity(
+        "Added \u001b[1m/tmp/demo\u001b[22m as a directory \u001b[2m· /permissions\u001b[22m",
+      ),
+    ).toEqual([
+      { text: "Added ", bold: false, dim: false },
+      { text: "/tmp/demo", bold: true, dim: false },
+      { text: " as a directory ", bold: false, dim: false },
+      { text: "· /permissions", bold: false, dim: true },
+    ]);
+  });
+
+  test("supports combined codes and resets all intensity with SGR zero", () => {
+    expect(parseAnsiIntensity("normal\u001b[1;2;31mstrong dim\u001b[0mnormal")).toEqual([
+      { text: "normal", bold: false, dim: false },
+      { text: "strong dim", bold: true, dim: true },
+      { text: "normal", bold: false, dim: false },
+    ]);
+  });
+
+  test("supports literal unicode escape and caret escape notation from logs", () => {
+    expect(parseAnsiIntensity("\\u001b[1mbold\\u001b[22m \\^[[2mdim\\^[[22m")).toEqual([
+      { text: "bold", bold: true, dim: false },
+      { text: " ", bold: false, dim: false },
+      { text: "dim", bold: false, dim: true },
+    ]);
+  });
+
+  test("removes unsupported SGR styling without applying unsafe presentation", () => {
+    expect(parseAnsiIntensity("before\u001b[31mred\u001b[39mafter")).toEqual([
+      { text: "beforeredafter", bold: false, dim: false },
+    ]);
+  });
+
+  test("preserves malformed and non-SGR escape text", () => {
+    expect(parseAnsiIntensity("before\u001b[1xbad after")).toEqual([
+      { text: "before\u001b[1xbad after", bold: false, dim: false },
+    ]);
+  });
+});
+
+describe("stripAnsiSgr", () => {
+  test("returns copyable plain text without control sequences", () => {
+    expect(stripAnsiSgr("\u001b[1m<script>alert(1)</script>\u001b[0m")).toBe(
+      "<script>alert(1)</script>",
+    );
+  });
+});

--- a/src/lib/ansi/parseAnsiIntensity.ts
+++ b/src/lib/ansi/parseAnsiIntensity.ts
@@ -1,0 +1,84 @@
+export type AnsiIntensitySegment = {
+  readonly text: string;
+  readonly bold: boolean;
+  readonly dim: boolean;
+};
+
+type IntensityState = {
+  readonly bold: boolean;
+  readonly dim: boolean;
+};
+
+const NORMAL_INTENSITY: IntensityState = {
+  bold: false,
+  dim: false,
+};
+
+const escapeCharacter = String.fromCodePoint(27);
+const sgrSequence = new RegExp(
+  `(?:${escapeCharacter}|\\\\u001b|\\\\x1b|\\\\?\\^\\[)\\[([0-9;]*)m`,
+  "giu",
+);
+
+const applySgrCode = (state: IntensityState, code: number): IntensityState => {
+  switch (code) {
+    case 0:
+    case 22:
+      return NORMAL_INTENSITY;
+    case 1:
+      return { ...state, bold: true };
+    case 2:
+      return { ...state, dim: true };
+    default:
+      return state;
+  }
+};
+
+const applySgrParameters = (state: IntensityState, parameters: string): IntensityState => {
+  const codes = parameters === "" ? [0] : parameters.split(";").map(Number);
+  return codes.reduce(applySgrCode, state);
+};
+
+const appendSegment = (
+  segments: AnsiIntensitySegment[],
+  text: string,
+  state: IntensityState,
+): void => {
+  if (text === "") return;
+
+  const previous = segments.at(-1);
+  if (previous?.bold === state.bold && previous.dim === state.dim) {
+    segments[segments.length - 1] = {
+      ...previous,
+      text: previous.text + text,
+    };
+    return;
+  }
+
+  segments.push({
+    text,
+    bold: state.bold,
+    dim: state.dim,
+  });
+};
+
+export const parseAnsiIntensity = (text: string): readonly AnsiIntensitySegment[] => {
+  const segments: AnsiIntensitySegment[] = [];
+  let state = NORMAL_INTENSITY;
+  let offset = 0;
+
+  for (const match of text.matchAll(sgrSequence)) {
+    const matchIndex = match.index;
+    appendSegment(segments, text.slice(offset, matchIndex), state);
+    state = applySgrParameters(state, match[1] ?? "");
+    offset = matchIndex + match[0].length;
+  }
+
+  appendSegment(segments, text.slice(offset), state);
+  return segments;
+};
+
+export const stripAnsiSgr = (text: string): string =>
+  parseAnsiIntensity(text)
+    .map((segment) => segment.text)
+    .join("");

--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -1301,8 +1301,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        42
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        40
       ]
     ],
     "translation": "Copy message"
@@ -1313,8 +1313,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        34
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        32
       ]
     ],
     "translation": "Failed to copy message"
@@ -1325,8 +1325,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        26
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        24
       ]
     ],
     "translation": "Message copied"

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -1301,8 +1301,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        42
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        40
       ]
     ],
     "translation": "メッセージをコピー"
@@ -1313,8 +1313,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        34
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        32
       ]
     ],
     "translation": "メッセージのコピーに失敗しました"
@@ -1325,8 +1325,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        26
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        24
       ]
     ],
     "translation": "メッセージをコピーしました"

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -1301,8 +1301,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        42
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        40
       ]
     ],
     "translation": "复制消息"
@@ -1313,8 +1313,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        34
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        32
       ]
     ],
     "translation": "复制消息失败"
@@ -1325,8 +1325,8 @@
     "comments": [],
     "origin": [
       [
-        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx",
-        26
+        "src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx",
+        24
       ]
     ],
     "translation": "消息已复制"

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText.test.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { AnsiText } from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText";
+
+describe("AnsiText", () => {
+  test("renders bold and dim text as React spans", () => {
+    const markup = renderToStaticMarkup(
+      <AnsiText text={"normal\u001b[1mbold\u001b[22m\u001b[2mdim\u001b[22m"} />,
+    );
+
+    expect(markup).toContain('<span class="font-bold">bold</span>');
+    expect(markup).toContain('<span class="opacity-60">dim</span>');
+    expect(markup).not.toContain("[1m");
+    expect(markup).not.toContain("[2m");
+  });
+
+  test("escapes text instead of interpreting it as HTML", () => {
+    const markup = renderToStaticMarkup(
+      <AnsiText text={"\u001b[1m<img src=x onerror=alert(1)>\u001b[0m"} />,
+    );
+
+    expect(markup).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(markup).not.toContain("<img");
+  });
+});

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText.tsx
@@ -1,0 +1,19 @@
+import type { FC } from "react";
+import { parseAnsiIntensity } from "@/lib/ansi/parseAnsiIntensity";
+import { cn } from "@/web/utils";
+
+export const AnsiText: FC<{ text: string }> = ({ text }) => (
+  <>
+    {parseAnsiIntensity(text).map((segment, index) => (
+      <span
+        key={`${index}:${segment.text}`}
+        className={cn({
+          "font-bold": segment.bold,
+          "opacity-60": segment.dim,
+        })}
+      >
+        {segment.text}
+      </span>
+    ))}
+  </>
+);

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationItem.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/ConversationItem.tsx
@@ -3,10 +3,10 @@ import { type FC, memo } from "react";
 import { parseUserMessage } from "@/lib/claude-code/parseUserMessage";
 import type { Conversation, SidechainConversation } from "@/lib/conversation-schema";
 import type { ToolResultContent } from "@/lib/conversation-schema/content/ToolResultContentSchema";
-import type { AssistantMessageContent } from "@/lib/conversation-schema/message/AssistantMessageSchema";
 import { formatLocaleDate } from "@/lib/date/formatLocaleDate";
 import { DEFAULT_LOCALE } from "@/lib/i18n/localeDetection";
 import { localeSchema, type SupportedLocale } from "@/lib/i18n/schema";
+import { CopyableAnsiText } from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableAnsiText";
 import { AssistantConversationContent } from "./AssistantConversationContent";
 import { FileHistorySnapshotConversationContent } from "./FileHistorySnapshotConversationContent";
 import { MetaConversationContent } from "./MetaConversationContent";
@@ -143,11 +143,6 @@ const ConversationItemComponent: FC<ConversationItemProps> = ({
       const parsed = parseUserMessage(conversation.message.content);
 
       if (parsed.kind === "local-command") {
-        const assistantContent: AssistantMessageContent = {
-          type: "text",
-          text: parsed.stdout,
-        };
-
         return (
           <div className="w-full">
             {showTimestamp && conversation.timestamp && (
@@ -160,17 +155,9 @@ const ConversationItemComponent: FC<ConversationItemProps> = ({
             )}
             <ul className="w-full">
               <li>
-                <AssistantConversationContent
-                  content={assistantContent}
-                  getToolResult={getToolResult}
-                  getAgentIdForToolUse={getAgentIdForToolUse}
-                  getToolUseResult={getToolUseResult}
-                  getSidechainConversationByAgentId={getSidechainConversationByAgentId}
-                  getSidechainConversationByPrompt={getSidechainConversationByPrompt}
-                  getSidechainConversations={getSidechainConversations}
-                  projectId={projectId}
-                  sessionId={sessionId}
-                />
+                <div className="w-full mx-1 sm:mx-2 my-4 sm:my-6">
+                  <CopyableAnsiText text={parsed.stdout} />
+                </div>
               </li>
             </ul>
           </div>

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableAnsiText.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableAnsiText.tsx
@@ -1,0 +1,15 @@
+import type { FC } from "react";
+import { stripAnsiSgr } from "@/lib/ansi/parseAnsiIntensity";
+import { AnsiText } from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText";
+import { CopyableContent } from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent";
+
+export const CopyableAnsiText: FC<{
+  text: string;
+  placement?: "user" | "assistant";
+}> = ({ text, placement = "assistant" }) => (
+  <CopyableContent content={stripAnsiSgr(text)} placement={placement}>
+    <pre className="text-sm overflow-x-auto whitespace-pre-wrap break-words">
+      <AnsiText text={text} />
+    </pre>
+  </CopyableContent>
+);

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent.tsx
@@ -1,0 +1,70 @@
+import { useLingui } from "@lingui/react";
+import { CopyIcon } from "lucide-react";
+import type { FC, PropsWithChildren } from "react";
+import { toast } from "sonner";
+import { Button } from "@/web/components/ui/button";
+import { cn } from "@/web/utils";
+
+type CopyableContentProps = PropsWithChildren<{
+  content: string;
+  placement?: "user" | "assistant";
+}>;
+
+export const CopyableContent: FC<CopyableContentProps> = ({
+  children,
+  content,
+  placement = "user",
+}) => {
+  const { i18n } = useLingui();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      toast.success(
+        i18n._({
+          id: "conversation.copy.success",
+          message: "Message copied",
+        }),
+      );
+    } catch (error) {
+      console.error("Failed to copy message:", error);
+      toast.error(
+        i18n._({
+          id: "conversation.copy.failed",
+          message: "Failed to copy message",
+        }),
+      );
+    }
+  };
+
+  const copyLabel = i18n._({
+    id: "conversation.copy",
+    message: "Copy message",
+  });
+
+  return (
+    <div className="group relative">
+      {children}
+      <div
+        className={cn("pointer-events-none absolute", {
+          "right-2 bottom-6": placement === "user",
+          "right-0 bottom-0 translate-x-1": placement === "assistant",
+        })}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="pointer-events-auto h-7 w-7 bg-background/85 opacity-100 md:opacity-0 shadow-sm transition-opacity md:group-hover:opacity-100 group-focus-within:opacity-100 backdrop-blur supports-[backdrop-filter]:bg-background/70"
+          onClick={() => {
+            void handleCopy();
+          }}
+          aria-label={copyLabel}
+          title={copyLabel}
+        >
+          <CopyIcon className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableMarkdownContent.tsx
@@ -1,10 +1,6 @@
-import { useLingui } from "@lingui/react";
-import { CopyIcon } from "lucide-react";
 import type { FC } from "react";
-import { toast } from "sonner";
-import { Button } from "@/web/components/ui/button";
-import { cn } from "@/web/utils";
-import { MarkdownContent } from "../../../../../../components/MarkdownContent";
+import { MarkdownContent } from "@/web/app/components/MarkdownContent";
+import { CopyableContent } from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/CopyableContent";
 
 type CopyableMarkdownContentProps = {
   content: string;
@@ -16,57 +12,8 @@ export const CopyableMarkdownContent: FC<CopyableMarkdownContentProps> = ({
   content,
   className,
   placement = "user",
-}) => {
-  const { i18n } = useLingui();
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(content);
-      toast.success(
-        i18n._({
-          id: "conversation.copy.success",
-          message: "Message copied",
-        }),
-      );
-    } catch (error) {
-      console.error("Failed to copy message:", error);
-      toast.error(
-        i18n._({
-          id: "conversation.copy.failed",
-          message: "Failed to copy message",
-        }),
-      );
-    }
-  };
-
-  const copyLabel = i18n._({
-    id: "conversation.copy",
-    message: "Copy message",
-  });
-
-  return (
-    <div className="group relative">
-      <MarkdownContent content={content} className={className} />
-      <div
-        className={cn("pointer-events-none absolute", {
-          "right-2 bottom-6": placement === "user",
-          "right-0 bottom-0 translate-x-1": placement === "assistant",
-        })}
-      >
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="pointer-events-auto h-7 w-7 bg-background/85 opacity-100 md:opacity-0 shadow-sm transition-opacity md:group-hover:opacity-100 group-focus-within:opacity-100 backdrop-blur supports-[backdrop-filter]:bg-background/70"
-          onClick={() => {
-            void handleCopy();
-          }}
-          aria-label={copyLabel}
-          title={copyLabel}
-        >
-          <CopyIcon className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-    </div>
-  );
-};
+}) => (
+  <CopyableContent content={content} placement={placement}>
+    <MarkdownContent content={content} className={className} />
+  </CopyableContent>
+);

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.test.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.test.tsx
@@ -1,5 +1,9 @@
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "vitest";
-import { convertNewlinesToBreaks } from "./UserTextContent";
+import {
+  convertNewlinesToBreaks,
+  UserTextContent,
+} from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent";
 
 describe("convertNewlinesToBreaks", () => {
   test("converts single newline to hard line break", () => {
@@ -24,5 +28,20 @@ describe("convertNewlinesToBreaks", () => {
 
   test("returns empty string unchanged", () => {
     expect(convertNewlinesToBreaks("")).toBe("");
+  });
+});
+
+describe("UserTextContent", () => {
+  test("renders ANSI intensity in local command output", () => {
+    const markup = renderToStaticMarkup(
+      <UserTextContent
+        text={
+          "<local-command-stdout>Added \u001b[1m/tmp/demo\u001b[22m \u001b[2m· hint\u001b[22m</local-command-stdout>"
+        }
+      />,
+    );
+
+    expect(markup).toContain('<span class="font-bold">/tmp/demo</span>');
+    expect(markup).toContain('<span class="opacity-60">· hint</span>');
   });
 });

--- a/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.tsx
+++ b/src/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/UserTextContent.tsx
@@ -1,6 +1,7 @@
 import { Terminal } from "lucide-react";
 import type { FC } from "react";
 import { parseUserMessage } from "@/lib/claude-code/parseUserMessage";
+import { AnsiText } from "@/web/app/projects/[projectId]/sessions/[sessionId]/components/conversationList/AnsiText";
 import { Badge } from "@/web/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/web/components/ui/card";
 import { CopyableMarkdownContent } from "./CopyableMarkdownContent";
@@ -90,7 +91,7 @@ export const UserTextContent: FC<{ text: string; id?: string }> = ({ text, id })
         </CardHeader>
         <CardContent className="py-0 px-4">
           <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
-            {parsed.stdout}
+            <AnsiText text={parsed.stdout} />
           </pre>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

- render ANSI SGR bold and dim intensity in local command output
- support actual ESC sequences plus literal Unicode and caret escape notation found in session logs
- strip unsupported SGR presentation and control sequences from copied text
- render terminal text as escaped React nodes instead of HTML
- preserve normal assistant Markdown rendering by limiting ANSI handling to local command output

Closes #215

## Security

- no `dangerouslySetInnerHTML` or raw HTML conversion
- no dependencies, workflow changes, or external communication
- HTML-like terminal output is rendered as escaped text

## Validation

- `pnpm gatecheck check`
- `./scripts/lingui-check.sh`
- `pnpm build:frontend`
- pre-push lint, typecheck, Lingui, and full test suite: 112 files / 1015 tests
- independent correctness and security reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local command output now displays ANSI bold and dim formatting correctly.
  * Added copyable, preformatted command output with ANSI control codes removed from copied text.
  * Standardized copy controls across conversation content, including localized success and failure notifications.
* **Bug Fixes**
  * HTML-like text in command output is safely displayed as text rather than interpreted as markup.
  * Improved handling of ANSI resets and unsupported styling sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->