### PR TITLE
fix: use MiniMax session pricing

### DIFF
--- a/src/server/core/session/constants/pricing.ts
+++ b/src/server/core/session/constants/pricing.ts
@@ -7,6 +7,8 @@
  */
 
 export type ModelName =
+  | "minimax-m3"
+  | "minimax-m2.7"
   | "claude-opus-4.5"
   | "claude-opus-4.1"
   | "claude-sonnet-4.5"
@@ -34,6 +36,18 @@ export type ModelPricing = {
  * since prompt length is not tracked at pricing calculation time.
  */
 export const MODEL_PRICING: Record<ModelName, ModelPricing> = {
+  "minimax-m3": {
+    input: 0.6,
+    output: 2.4,
+    cache_creation: 0,
+    cache_read: 0.12,
+  },
+  "minimax-m2.7": {
+    input: 0.3,
+    output: 1.2,
+    cache_creation: 0.375,
+    cache_read: 0.06,
+  },
   "claude-opus-4.5": {
     input: 5.0,
     output: 25.0,

--- a/src/server/core/session/constants/pricing.ts
+++ b/src/server/core/session/constants/pricing.ts
@@ -1,13 +1,15 @@
 /**
- * Anthropic Claude API Pricing Information
- * Last updated: 2026-01-08
+ * Model pricing information
  *
  * Prices are in USD per million tokens (MTok)
- * Source: https://claude.com/pricing
+ * Sources:
+ * - https://claude.com/pricing
+ * - https://platform.minimax.io/docs/guides/pricing-paygo
  */
 
 export type ModelName =
   | "minimax-m3"
+  | "minimax-m2.7-highspeed"
   | "minimax-m2.7"
   | "claude-opus-4.5"
   | "claude-opus-4.1"
@@ -32,15 +34,30 @@ export type ModelPricing = {
  * Note: Claude Sonnet 4.5 has tiered pricing based on prompt length:
  * - ≤200K tokens: $3/$15 (standard tier, used here)
  * - >200K tokens: $6/$22.50 (extended context tier, not implemented)
- * This implementation uses standard tier pricing as the default approximation
- * since prompt length is not tracked at pricing calculation time.
+ * This implementation uses standard Claude pricing as the default approximation.
+ * MiniMax-M3 pricing is selected from the total reported input token count.
  */
+export const MINIMAX_M3_LONG_CONTEXT_THRESHOLD_TOKENS = 512_000;
+
+export const MINIMAX_M3_LONG_CONTEXT_PRICING: ModelPricing = {
+  input: 0.6,
+  output: 2.4,
+  cache_creation: 0,
+  cache_read: 0.12,
+};
+
 export const MODEL_PRICING: Record<ModelName, ModelPricing> = {
   "minimax-m3": {
+    input: 0.3,
+    output: 1.2,
+    cache_creation: 0,
+    cache_read: 0.06,
+  },
+  "minimax-m2.7-highspeed": {
     input: 0.6,
     output: 2.4,
-    cache_creation: 0,
-    cache_read: 0.12,
+    cache_creation: 0.375,
+    cache_read: 0.06,
   },
   "minimax-m2.7": {
     input: 0.3,

--- a/src/server/core/session/functions/calculateSessionCost.test.ts
+++ b/src/server/core/session/functions/calculateSessionCost.test.ts
@@ -34,6 +34,11 @@ describe("normalizeModelName", () => {
     expect(normalizeModelName("claude-haiku-4-5-20251001")).toBe("claude-haiku-4.5");
   });
 
+  it("should normalize MiniMax model names", () => {
+    expect(normalizeModelName("MiniMax-M3")).toBe("minimax-m3");
+    expect(normalizeModelName("MiniMax-M2.7")).toBe("minimax-m2.7");
+  });
+
   it("should return claude-3.5-sonnet for unknown model", () => {
     expect(normalizeModelName("unknown-model")).toBe("claude-3.5-sonnet");
   });
@@ -219,6 +224,40 @@ describe("calculateTokenCost", () => {
     expect(result.breakdown.outputTokensUsd).toBeCloseTo(0.25, 4);
     expect(result.breakdown.cacheCreationUsd).toBeCloseTo(0.0125, 4);
     expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.0005, 4);
+  });
+
+  it("should calculate cost for MiniMax-M3", () => {
+    const usage: TokenUsage = {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+    };
+
+    const result = calculateTokenCost(usage, "MiniMax-M3");
+
+    expect(result.totalUsd).toBeCloseTo(3.12, 4);
+    expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.6, 4);
+    expect(result.breakdown.outputTokensUsd).toBeCloseTo(2.4, 4);
+    expect(result.breakdown.cacheCreationUsd).toBe(0);
+    expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.12, 4);
+  });
+
+  it("should calculate cost for MiniMax-M2.7", () => {
+    const usage: TokenUsage = {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+    };
+
+    const result = calculateTokenCost(usage, "MiniMax-M2.7");
+
+    expect(result.totalUsd).toBeCloseTo(1.935, 4);
+    expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.3, 4);
+    expect(result.breakdown.outputTokensUsd).toBeCloseTo(1.2, 4);
+    expect(result.breakdown.cacheCreationUsd).toBeCloseTo(0.375, 4);
+    expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.06, 4);
   });
 
   it("should handle optional cache tokens (undefined)", () => {

--- a/src/server/core/session/functions/calculateSessionCost.test.ts
+++ b/src/server/core/session/functions/calculateSessionCost.test.ts
@@ -37,6 +37,7 @@ describe("normalizeModelName", () => {
   it("should normalize MiniMax model names", () => {
     expect(normalizeModelName("MiniMax-M3")).toBe("minimax-m3");
     expect(normalizeModelName("MiniMax-M2.7")).toBe("minimax-m2.7");
+    expect(normalizeModelName("MiniMax-M2.7-highspeed")).toBe("minimax-m2.7-highspeed");
   });
 
   it("should return claude-3.5-sonnet for unknown model", () => {
@@ -226,21 +227,38 @@ describe("calculateTokenCost", () => {
     expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.0005, 4);
   });
 
-  it("should calculate cost for MiniMax-M3", () => {
+  it("should calculate the standard MiniMax-M3 tier at 512k total input tokens", () => {
     const usage: TokenUsage = {
-      input_tokens: 1_000_000,
+      input_tokens: 100_000,
       output_tokens: 1_000_000,
-      cache_creation_input_tokens: 1_000_000,
-      cache_read_input_tokens: 1_000_000,
+      cache_creation_input_tokens: 200_000,
+      cache_read_input_tokens: 212_000,
     };
 
     const result = calculateTokenCost(usage, "MiniMax-M3");
 
-    expect(result.totalUsd).toBeCloseTo(3.12, 4);
-    expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.6, 4);
-    expect(result.breakdown.outputTokensUsd).toBeCloseTo(2.4, 4);
+    expect(result.totalUsd).toBeCloseTo(1.24272, 5);
+    expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.03, 5);
+    expect(result.breakdown.outputTokensUsd).toBeCloseTo(1.2, 5);
     expect(result.breakdown.cacheCreationUsd).toBe(0);
-    expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.12, 4);
+    expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.01272, 5);
+  });
+
+  it("should calculate the long-context MiniMax-M3 tier above 512k total input tokens", () => {
+    const usage: TokenUsage = {
+      input_tokens: 100_000,
+      output_tokens: 1_000_000,
+      cache_creation_input_tokens: 200_000,
+      cache_read_input_tokens: 212_001,
+    };
+
+    const result = calculateTokenCost(usage, "MiniMax-M3");
+
+    expect(result.totalUsd).toBeCloseTo(2.48544012, 6);
+    expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.06, 5);
+    expect(result.breakdown.outputTokensUsd).toBeCloseTo(2.4, 5);
+    expect(result.breakdown.cacheCreationUsd).toBe(0);
+    expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.02544012, 6);
   });
 
   it("should calculate cost for MiniMax-M2.7", () => {
@@ -256,6 +274,23 @@ describe("calculateTokenCost", () => {
     expect(result.totalUsd).toBeCloseTo(1.935, 4);
     expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.3, 4);
     expect(result.breakdown.outputTokensUsd).toBeCloseTo(1.2, 4);
+    expect(result.breakdown.cacheCreationUsd).toBeCloseTo(0.375, 4);
+    expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.06, 4);
+  });
+
+  it("should calculate cost for MiniMax-M2.7-highspeed", () => {
+    const usage: TokenUsage = {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+    };
+
+    const result = calculateTokenCost(usage, "MiniMax-M2.7-highspeed");
+
+    expect(result.totalUsd).toBeCloseTo(3.435, 4);
+    expect(result.breakdown.inputTokensUsd).toBeCloseTo(0.6, 4);
+    expect(result.breakdown.outputTokensUsd).toBeCloseTo(2.4, 4);
     expect(result.breakdown.cacheCreationUsd).toBeCloseTo(0.375, 4);
     expect(result.breakdown.cacheReadUsd).toBeCloseTo(0.06, 4);
   });

--- a/src/server/core/session/functions/calculateSessionCost.ts
+++ b/src/server/core/session/functions/calculateSessionCost.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_MODEL_PRICING,
+  MINIMAX_M3_LONG_CONTEXT_PRICING,
+  MINIMAX_M3_LONG_CONTEXT_THRESHOLD_TOKENS,
   MODEL_PRICING,
   type ModelName,
   type ModelPricing,
@@ -67,6 +69,10 @@ export const normalizeModelName = (modelName: string): ModelName => {
     return "minimax-m3";
   }
 
+  if (normalized.includes("minimax-m2.7-highspeed")) {
+    return "minimax-m2.7-highspeed";
+  }
+
   if (normalized.includes("minimax-m2.7")) {
     return "minimax-m2.7";
   }
@@ -117,8 +123,17 @@ export const normalizeModelName = (modelName: string): ModelName => {
 /**
  * Gets pricing for a model, with fallback to default pricing
  */
-const getModelPricing = (modelName: string): ModelPricing => {
+const getModelPricing = (modelName: string, usage: TokenUsage): ModelPricing => {
   const normalized = normalizeModelName(modelName);
+  const totalInputTokens =
+    usage.input_tokens +
+    (usage.cache_creation_input_tokens ?? 0) +
+    (usage.cache_read_input_tokens ?? 0);
+
+  if (normalized === "minimax-m3" && totalInputTokens > MINIMAX_M3_LONG_CONTEXT_THRESHOLD_TOKENS) {
+    return MINIMAX_M3_LONG_CONTEXT_PRICING;
+  }
+
   return MODEL_PRICING[normalized] ?? DEFAULT_MODEL_PRICING;
 };
 
@@ -130,7 +145,7 @@ const getModelPricing = (modelName: string): ModelPricing => {
  * @returns Cost calculation result with breakdown
  */
 export const calculateTokenCost = (usage: TokenUsage, modelName: string): CostCalculationResult => {
-  const pricing = getModelPricing(modelName);
+  const pricing = getModelPricing(modelName, usage);
 
   // Convert tokens to millions for cost calculation
   const inputMTok = usage.input_tokens / 1_000_000;

--- a/src/server/core/session/functions/calculateSessionCost.ts
+++ b/src/server/core/session/functions/calculateSessionCost.ts
@@ -63,6 +63,14 @@ export type CostCalculationResult = {
 export const normalizeModelName = (modelName: string): ModelName => {
   const normalized = modelName.toLowerCase();
 
+  if (normalized.includes("minimax-m3")) {
+    return "minimax-m3";
+  }
+
+  if (normalized.includes("minimax-m2.7")) {
+    return "minimax-m2.7";
+  }
+
   // Claude Opus 4.5 patterns (more specific first)
   if (normalized.includes("opus-4-5") || normalized.includes("opus-4.5")) {
     return "claude-opus-4.5";


### PR DESCRIPTION
Reason: MiniMax sessions currently fall back to unrelated pricing instead of using the configured model rates.

This adds explicit session-cost pricing and model normalization for MiniMax-M3 and MiniMax-M2.7, including input, output, cache-read, and cache-write token costs.

Checks:

- `node_modules/.bin/oxfmt --write src/server/core/session/constants/pricing.ts src/server/core/session/functions/calculateSessionCost.ts src/server/core/session/functions/calculateSessionCost.test.ts`
- `node_modules/.bin/vitest --run src/server/core/session/functions/calculateSessionCost.test.ts`
- `node_modules/.bin/tsgo --noEmit`
- `node_modules/.bin/oxlint --ignore-path .gitignore --no-error-on-unmatched-pattern src/server/core/session/constants/pricing.ts src/server/core/session/functions/calculateSessionCost.ts src/server/core/session/functions/calculateSessionCost.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MiniMax M3, MiniMax M2.7, and MiniMax M2.7 Highspeed models.
  * Added pricing for input, output, cache creation, and cache reads.
  * Added long-context pricing for MiniMax M3.

* **Bug Fixes**
  * Improved session cost calculation accuracy across supported MiniMax models and usage tiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->