### PR TITLE
feat: support video attachments

### DIFF
--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -135,7 +135,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        487
+        493
       ]
     ],
     "translation": "Message input with autocomplete support"
@@ -536,7 +536,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        579
+        585
       ]
     ],
     "translation": "Attach"
@@ -559,7 +559,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        209
+        211
       ]
     ],
     "translation": "Failed to copy command"
@@ -571,7 +571,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        202
+        204
       ]
     ],
     "translation": "Command copied to clipboard"
@@ -582,7 +582,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        453
+        459
       ]
     ],
     "translation": "Failed to send message. Please try again."
@@ -778,7 +778,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        299
+        304
       ]
     ],
     "translation": "Failed to schedule message"
@@ -790,7 +790,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        283
+        288
       ]
     ],
     "translation": "Message scheduled successfully"
@@ -802,7 +802,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        288
+        293
       ]
     ],
     "translation": "You can view and manage it in the Scheduler tab"
@@ -824,7 +824,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        532
+        538
       ]
     ],
     "translation": "Send Now"
@@ -835,7 +835,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        517
+        523
       ]
     ],
     "translation": "Send Mode"
@@ -846,11 +846,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        535
+        541
       ],
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        674
+        680
       ]
     ],
     "translation": "Schedule Send"
@@ -861,7 +861,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        542
+        548
       ]
     ],
     "translation": "Scheduled Send Time"
@@ -901,7 +901,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        644
+        650
       ]
     ],
     "translation": "Select reasoning effort"
@@ -913,7 +913,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        612
+        618
       ]
     ],
     "translation": "Select model"
@@ -1009,7 +1009,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        714
+        720
       ]
     ],
     "translation": "Voice input"

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -135,7 +135,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        487
+        493
       ]
     ],
     "translation": "補完機能付きメッセージ入力"
@@ -536,7 +536,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        579
+        585
       ]
     ],
     "translation": "添付"
@@ -559,7 +559,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        209
+        211
       ]
     ],
     "translation": "コマンドのコピーに失敗しました"
@@ -571,7 +571,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        202
+        204
       ]
     ],
     "translation": "コマンドをクリップボードにコピーしました"
@@ -582,7 +582,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        453
+        459
       ]
     ],
     "translation": "メッセージの送信に失敗しました。もう一度お試しください。"
@@ -778,7 +778,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        299
+        304
       ]
     ],
     "translation": "メッセージの予約に失敗しました"
@@ -790,7 +790,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        283
+        288
       ]
     ],
     "translation": "メッセージを予約しました"
@@ -802,7 +802,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        288
+        293
       ]
     ],
     "translation": "スケジューラタブで確認・管理できます"
@@ -824,7 +824,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        532
+        538
       ]
     ],
     "translation": "今すぐ送信"
@@ -835,7 +835,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        517
+        523
       ]
     ],
     "translation": "送信モード"
@@ -846,11 +846,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        535
+        541
       ],
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        674
+        680
       ]
     ],
     "translation": "予約送信"
@@ -861,7 +861,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        542
+        548
       ]
     ],
     "translation": "送信予定時刻"
@@ -901,7 +901,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        644
+        650
       ]
     ],
     "translation": "Reasoning effort を選択"
@@ -913,7 +913,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        612
+        618
       ]
     ],
     "translation": "モデルを選択"
@@ -1009,7 +1009,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        714
+        720
       ]
     ],
     "translation": "音声入力"

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -135,7 +135,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        487
+        493
       ]
     ],
     "translation": "带补全支持的消息输入"
@@ -536,7 +536,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        579
+        585
       ]
     ],
     "translation": "附加"
@@ -559,7 +559,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        209
+        211
       ]
     ],
     "translation": "复制命令失败"
@@ -571,7 +571,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        202
+        204
       ]
     ],
     "translation": "命令已复制到剪贴板"
@@ -582,7 +582,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        453
+        459
       ]
     ],
     "translation": "发送消息失败。请重试。"
@@ -778,7 +778,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        299
+        304
       ]
     ],
     "translation": "定时发送消息失败"
@@ -790,7 +790,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        283
+        288
       ]
     ],
     "translation": "消息定时发送成功"
@@ -802,7 +802,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        288
+        293
       ]
     ],
     "translation": "您可以在定时任务选项卡中查看和管理"
@@ -824,7 +824,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        532
+        538
       ]
     ],
     "translation": "立即发送"
@@ -835,7 +835,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        517
+        523
       ]
     ],
     "translation": "发送模式"
@@ -846,11 +846,11 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        535
+        541
       ],
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        674
+        680
       ]
     ],
     "translation": "定时发送"
@@ -861,7 +861,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        542
+        548
       ]
     ],
     "translation": "定时发送时间"
@@ -901,7 +901,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        644
+        650
       ]
     ],
     "translation": "选择推理努力程度"
@@ -913,7 +913,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        612
+        618
       ]
     ],
     "translation": "选择模型"
@@ -1009,7 +1009,7 @@
     "origin": [
       [
         "src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx",
-        714
+        720
       ]
     ],
     "translation": "语音输入"

--- a/src/server/core/claude-code/functions/createMessageGenerator.test.ts
+++ b/src/server/core/claude-code/functions/createMessageGenerator.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createMessageGenerator } from "./createMessageGenerator.ts";
+
+describe("createMessageGenerator", () => {
+  it("includes video blocks in generated user messages", async () => {
+    const { generateMessages, setNextMessage } = createMessageGenerator();
+    const messages = generateMessages();
+    const nextMessage = messages.next();
+
+    setNextMessage({
+      text: "Describe this video",
+      videos: [
+        {
+          type: "video",
+          source: {
+            type: "base64",
+            media_type: "video/mp4",
+            data: "encoded-video",
+          },
+        },
+      ],
+    });
+
+    await expect(nextMessage).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this video" },
+            {
+              type: "video",
+              source: {
+                type: "base64",
+                media_type: "video/mp4",
+                data: "encoded-video",
+              },
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    });
+
+    await messages.return();
+  });
+});

--- a/src/server/core/claude-code/functions/createMessageGenerator.ts
+++ b/src/server/core/claude-code/functions/createMessageGenerator.ts
@@ -1,12 +1,43 @@
 import type { SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { DocumentBlockParam, ImageBlockParam } from "@anthropic-ai/sdk/resources";
+import { z } from "zod";
 import { controllablePromise } from "../../../../lib/controllablePromise.ts";
+import {
+  documentBlockSchema,
+  imageBlockSchema,
+  type VideoBlockParam,
+  videoBlockSchema,
+} from "../schema.ts";
 
 export type UserMessageInput = {
   text: string;
   images?: readonly ImageBlockParam[];
+  videos?: readonly VideoBlockParam[];
   documents?: readonly DocumentBlockParam[];
 };
+
+const generatedUserMessageSchema = z.object({
+  type: z.literal("user"),
+  message: z.object({
+    role: z.literal("user"),
+    content: z.union([
+      z.string(),
+      z.array(
+        z.union([
+          z.object({ type: z.literal("text"), text: z.string() }),
+          imageBlockSchema,
+          videoBlockSchema,
+          documentBlockSchema,
+        ]),
+      ),
+    ]),
+  }),
+  parent_tool_use_id: z.null(),
+});
+
+const sdkUserMessageSchema = z.custom<SDKUserMessage>(
+  (value) => generatedUserMessageSchema.safeParse(value).success,
+);
 
 export type OnMessage = (message: SDKMessage) => void | Promise<void>;
 
@@ -30,20 +61,20 @@ export const createMessageGenerator = (): {
   };
 
   const createMessage = (input: UserMessageInput): SDKUserMessage => {
-    const { images = [], documents = [] } = input;
+    const { images = [], videos = [], documents = [] } = input;
 
-    if (images.length === 0 && documents.length === 0) {
-      return {
+    if (images.length === 0 && videos.length === 0 && documents.length === 0) {
+      return sdkUserMessageSchema.parse({
         type: "user",
         message: {
           role: "user",
           content: input.text,
         },
         parent_tool_use_id: null,
-      } satisfies SDKUserMessage;
+      });
     }
 
-    return {
+    return sdkUserMessageSchema.parse({
       type: "user",
       message: {
         role: "user",
@@ -53,11 +84,12 @@ export const createMessageGenerator = (): {
             text: input.text,
           },
           ...images,
+          ...videos,
           ...documents,
         ],
       },
       parent_tool_use_id: null,
-    } satisfies SDKUserMessage;
+    });
   };
 
   const generateMessages = async function* (): ReturnType<MessageGenerator> {

--- a/src/server/core/claude-code/schema.test.ts
+++ b/src/server/core/claude-code/schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { userMessageInputSchema } from "./schema.ts";
+
+describe("userMessageInputSchema", () => {
+  it("preserves supported base64 video blocks", () => {
+    const videos = [
+      "video/mp4",
+      "video/avi",
+      "video/x-msvideo",
+      "video/mov",
+      "video/x-matroska",
+    ].map((mediaType) => ({
+      type: "video",
+      source: {
+        type: "base64",
+        media_type: mediaType,
+        data: "encoded-video",
+      },
+    }));
+
+    const result = userMessageInputSchema.parse({
+      text: "Describe these videos",
+      videos,
+    });
+
+    expect(result.videos).toEqual(videos);
+  });
+
+  it("rejects unsupported video media types", () => {
+    const result = userMessageInputSchema.safeParse({
+      text: "Describe this video",
+      videos: [
+        {
+          type: "video",
+          source: {
+            type: "base64",
+            media_type: "video/webm",
+            data: "encoded-video",
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/server/core/claude-code/schema.ts
+++ b/src/server/core/claude-code/schema.ts
@@ -14,10 +14,20 @@ export const mediaTypeSchema = z.enum(["image/png", "image/jpeg", "image/gif", "
 
 export type MediaType = z.infer<typeof mediaTypeSchema>;
 
+export const videoMediaTypeSchema = z.enum([
+  "video/mp4",
+  "video/avi",
+  "video/x-msvideo",
+  "video/mov",
+  "video/x-matroska",
+]);
+
+export type VideoMediaType = z.infer<typeof videoMediaTypeSchema>;
+
 /**
  * Schema for image block parameter
  */
-const imageBlockSchema = z.object({
+export const imageBlockSchema = z.object({
   type: z.literal("image"),
   source: z.object({
     type: z.literal("base64"),
@@ -31,7 +41,7 @@ export type ImageBlockParam = z.infer<typeof imageBlockSchema>;
 /**
  * Schema for document block parameter
  */
-const documentBlockSchema = z.object({
+export const documentBlockSchema = z.object({
   type: z.literal("document"),
   source: z.union([
     z.object({
@@ -49,12 +59,24 @@ const documentBlockSchema = z.object({
 
 export type DocumentBlockParam = z.infer<typeof documentBlockSchema>;
 
+export const videoBlockSchema = z.object({
+  type: z.literal("video"),
+  source: z.object({
+    type: z.literal("base64"),
+    media_type: videoMediaTypeSchema,
+    data: z.string(),
+  }),
+});
+
+export type VideoBlockParam = z.infer<typeof videoBlockSchema>;
+
 /**
- * Schema for user message input with optional images and documents
+ * Schema for user message input with optional media and documents
  */
 export const userMessageInputSchema = z.object({
   text: z.string().min(1),
   images: z.array(imageBlockSchema).optional(),
+  videos: z.array(videoBlockSchema).optional(),
   documents: z.array(documentBlockSchema).optional(),
 });
 

--- a/src/server/hono/routes/claudeCodeRoutes.ts
+++ b/src/server/hono/routes/claudeCodeRoutes.ts
@@ -24,10 +24,15 @@ const normalizeUserMessageInput = (
     type: document.type,
     source: document.source,
   }));
+  const videos = input.videos?.map((video) => ({
+    type: video.type,
+    source: video.source,
+  }));
 
   return {
     text: input.text,
     images,
+    videos,
     documents,
   };
 };

--- a/src/web/app/projects/[projectId]/components/chatForm/ChatInput.test.tsx
+++ b/src/web/app/projects/[projectId]/components/chatForm/ChatInput.test.tsx
@@ -152,6 +152,52 @@ describe("ChatInput", () => {
     expect(container?.textContent).not.toContain("clipboard-image.png");
   });
 
+  it("submits selected video attachments as video blocks", async () => {
+    const onSubmit = vi.fn(async () => {});
+    renderComponent({ onSubmit });
+    const input = container?.querySelector('input[type="file"]');
+    expect(input).not.toBeNull();
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error("File input not found");
+    }
+
+    const videoFile = new File(["video"], "clip.mp4", { type: "video/mp4" });
+    Object.defineProperty(input, "files", { value: [videoFile] });
+    act(() => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const buttons = container?.querySelectorAll("button");
+    const sendButton = buttons?.item((buttons?.length ?? 0) - 1);
+    expect(sendButton).not.toBeNull();
+    if (!(sendButton instanceof HTMLButtonElement)) {
+      throw new Error("Send button not found");
+    }
+
+    act(() => {
+      sendButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        text: "",
+        videos: [
+          {
+            type: "video",
+            source: {
+              type: "base64",
+              media_type: "video/mp4",
+              data: "dmlkZW8=",
+            },
+          },
+        ],
+        images: undefined,
+        documents: undefined,
+        ccOptions: undefined,
+      });
+    });
+  });
+
   it("should have correct type definition for enableScheduledSend", () => {
     const props: ChatInputProps = {
       projectId: "test-project",

--- a/src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx
+++ b/src/web/app/projects/[projectId]/components/chatForm/ChatInput.tsx
@@ -17,6 +17,7 @@ import type {
   CCOptionsSchema,
   DocumentBlockParam,
   ImageBlockParam,
+  VideoBlockParam,
 } from "@/server/core/claude-code/schema";
 import { buildClaudeCommand } from "@/web/lib/claude-command";
 import { Button } from "../../../../../components/ui/button";
@@ -44,6 +45,7 @@ import { InlineCompletion } from "./InlineCompletion";
 export type MessageInput = {
   text: string;
   images?: ImageBlockParam[];
+  videos?: VideoBlockParam[];
   documents?: DocumentBlockParam[];
   ccOptions?: CCOptionsSchema;
 };
@@ -224,6 +226,7 @@ export const ChatInput: FC<ChatInputProps> = ({
     if (isPending || disabled || sendDisabled) return;
 
     const images: ImageBlockParam[] = [];
+    const videos: VideoBlockParam[] = [];
     const documents: DocumentBlockParam[] = [];
 
     for (const { file } of attachedFiles) {
@@ -244,6 +247,8 @@ export const ChatInput: FC<ChatInputProps> = ({
         });
       } else if (result.type === "image") {
         images.push(result.block);
+      } else if (result.type === "video") {
+        videos.push(result.block);
       } else if (result.type === "document") {
         documents.push(result.block);
       }
@@ -311,6 +316,7 @@ export const ChatInput: FC<ChatInputProps> = ({
         await onSubmit({
           text: message,
           images: images.length > 0 ? images : undefined,
+          videos: videos.length > 0 ? videos : undefined,
           documents: documents.length > 0 ? documents : undefined,
           ccOptions,
         });

--- a/src/web/app/projects/[projectId]/components/chatForm/fileUtils.test.ts
+++ b/src/web/app/projects/[projectId]/components/chatForm/fileUtils.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { determineFileType, isSupportedMimeType, processFile } from "./fileUtils.ts";
+
+describe("video attachments", () => {
+  it("recognizes supported video MIME types", () => {
+    expect(determineFileType("video/mp4")).toBe("video");
+    expect(isSupportedMimeType("video/mp4")).toBe(true);
+    expect(isSupportedMimeType("video/avi")).toBe(true);
+    expect(isSupportedMimeType("video/x-msvideo")).toBe(true);
+    expect(isSupportedMimeType("video/quicktime")).toBe(true);
+    expect(isSupportedMimeType("video/x-matroska")).toBe(true);
+    expect(isSupportedMimeType("video/webm")).toBe(false);
+  });
+
+  it("converts MOV files to the supported base64 media type", async () => {
+    const file = new File(["video"], "clip.mov", { type: "video/quicktime" });
+
+    await expect(processFile(file)).resolves.toEqual({
+      type: "video",
+      block: {
+        type: "video",
+        source: {
+          type: "base64",
+          media_type: "video/mov",
+          data: "dmlkZW8=",
+        },
+      },
+    });
+  });
+});

--- a/src/web/app/projects/[projectId]/components/chatForm/fileUtils.ts
+++ b/src/web/app/projects/[projectId]/components/chatForm/fileUtils.ts
@@ -1,9 +1,30 @@
 import { z } from "zod";
-import type { DocumentBlockParam, ImageBlockParam } from "@/server/core/claude-code/schema";
+import type {
+  DocumentBlockParam,
+  ImageBlockParam,
+  VideoBlockParam,
+} from "@/server/core/claude-code/schema";
 
 const mediaTypeSchema = z.enum(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const videoMediaTypeSchema = z.enum([
+  "video/mp4",
+  "video/avi",
+  "video/x-msvideo",
+  "video/mov",
+  "video/x-matroska",
+]);
+type VideoMediaType = z.infer<typeof videoMediaTypeSchema>;
 
-export type FileType = "text" | "image" | "pdf";
+const videoMediaTypeByFileType: Readonly<Record<string, VideoMediaType>> = {
+  "video/mp4": "video/mp4",
+  "video/avi": "video/avi",
+  "video/x-msvideo": "video/x-msvideo",
+  "video/quicktime": "video/mov",
+  "video/mov": "video/mov",
+  "video/x-matroska": "video/x-matroska",
+};
+
+export type FileType = "text" | "image" | "video" | "pdf";
 
 /**
  * Determine file type based on MIME type
@@ -11,6 +32,9 @@ export type FileType = "text" | "image" | "pdf";
 export const determineFileType = (mimeType: string): FileType => {
   if (mimeType.startsWith("image/")) {
     return "image";
+  }
+  if (mimeType.startsWith("video/")) {
+    return "video";
   }
   if (mimeType === "application/pdf") {
     return "pdf";
@@ -28,6 +52,7 @@ export const isSupportedMimeType = (mimeType: string): boolean => {
 
   return (
     supportedImageTypes.includes(mimeType) ||
+    Object.hasOwn(videoMediaTypeByFileType, mimeType) ||
     supportedDocumentTypes.includes(mimeType) ||
     supportedTextTypes.includes(mimeType)
   );
@@ -109,6 +134,7 @@ export const processFile = async (
 ): Promise<
   | { type: "text"; content: string }
   | { type: "image"; block: ImageBlockParam }
+  | { type: "video"; block: VideoBlockParam }
   | { type: "document"; block: DocumentBlockParam }
   | null
 > => {
@@ -131,6 +157,25 @@ export const processFile = async (
       type: "image",
       block: {
         type: "image",
+        source: {
+          type: "base64",
+          media_type: mediaType.data,
+          data: base64Data,
+        },
+      },
+    };
+  }
+
+  if (fileType === "video") {
+    const mediaType = videoMediaTypeSchema.safeParse(videoMediaTypeByFileType[file.type]);
+    if (!mediaType.success) {
+      return null;
+    }
+
+    return {
+      type: "video",
+      block: {
+        type: "video",
         source: {
           type: "base64",
           media_type: mediaType.data,


### PR DESCRIPTION
Reason: Allow supported sessions to receive video attachments through the existing chat attachment flow.

- Accept MP4, AVI, MOV, and MKV uploads and normalize browser-specific MOV MIME data.
- Validate and forward base64 video blocks through the request and message-generation pipeline.
- Cover MIME filtering, request validation, UI submission, and generated message content with tests.

Checks:

- `pnpm typecheck`
- `pnpm gatecheck check`
- `./scripts/lingui-check.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching and sending video files in chat messages.
  * Supported videos are converted to base64 attachments with validated media types.
  * Video content is preserved alongside text, images, and documents.

* **Bug Fixes**
  * Improved message validation and normalization for multimodal messages.

* **Tests**
  * Added coverage for video uploads, supported formats, encoding, submission, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->