### PR TITLE
fix: prevent stale clients after upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "web-push": "^3.6.7",
     "webpack": "5.106.2",
     "workbox-build": "^7.4.1",
+    "workbox-core": "^7.4.1",
     "workbox-expiration": "^7.4.1",
     "workbox-precaching": "^7.4.1",
     "workbox-routing": "^7.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       workbox-build:
         specifier: ^7.4.1
         version: 7.4.1
+      workbox-core:
+        specifier: ^7.4.1
+        version: 7.4.1
       workbox-expiration:
         specifier: ^7.4.1
         version: 7.4.1

--- a/src/lib/pwa/enableImmediateServiceWorkerUpdate.test.ts
+++ b/src/lib/pwa/enableImmediateServiceWorkerUpdate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test, vi } from "vitest";
+import { enableImmediateServiceWorkerUpdate } from "./enableImmediateServiceWorkerUpdate.ts";
+
+describe("enableImmediateServiceWorkerUpdate", () => {
+  test("claims open clients and activates the latest worker without waiting for tabs to close", async () => {
+    const claimClients = vi.fn();
+    const skipWaiting = vi.fn(() => Promise.resolve());
+
+    await enableImmediateServiceWorkerUpdate({ claimClients, skipWaiting });
+
+    expect(claimClients).toHaveBeenCalledOnce();
+    expect(skipWaiting).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/pwa/enableImmediateServiceWorkerUpdate.test.ts
+++ b/src/lib/pwa/enableImmediateServiceWorkerUpdate.test.ts
@@ -3,11 +3,21 @@ import { enableImmediateServiceWorkerUpdate } from "./enableImmediateServiceWork
 
 describe("enableImmediateServiceWorkerUpdate", () => {
   test("claims open clients and activates the latest worker without waiting for tabs to close", async () => {
-    const claimClients = vi.fn();
-    const skipWaiting = vi.fn(() => Promise.resolve());
+    const calls: string[] = [];
+    const activation = Promise.resolve();
+    const claimClients = vi.fn(() => {
+      calls.push("claimClients");
+    });
+    const skipWaiting = vi.fn(() => {
+      calls.push("skipWaiting");
+      return activation;
+    });
 
-    await enableImmediateServiceWorkerUpdate({ claimClients, skipWaiting });
+    const result = enableImmediateServiceWorkerUpdate({ claimClients, skipWaiting });
 
+    expect(result).toBe(activation);
+    await result;
+    expect(calls).toEqual(["claimClients", "skipWaiting"]);
     expect(claimClients).toHaveBeenCalledOnce();
     expect(skipWaiting).toHaveBeenCalledOnce();
   });

--- a/src/lib/pwa/enableImmediateServiceWorkerUpdate.ts
+++ b/src/lib/pwa/enableImmediateServiceWorkerUpdate.ts
@@ -1,0 +1,12 @@
+type ServiceWorkerUpdateActions = {
+  claimClients: () => void;
+  skipWaiting: () => Promise<void>;
+};
+
+export const enableImmediateServiceWorkerUpdate = ({
+  claimClients,
+  skipWaiting,
+}: ServiceWorkerUpdateActions): Promise<void> => {
+  claimClients();
+  return skipWaiting();
+};

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,5 +1,6 @@
 /// <reference lib="webworker" />
 
+import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import {
   cleanupOutdatedCaches,
@@ -9,10 +10,16 @@ import {
 import { NavigationRoute, registerRoute } from "workbox-routing";
 import { NetworkFirst, NetworkOnly } from "workbox-strategies";
 import { getBasePathHref, joinBasePath, normalizeBasePath } from "./lib/base-path/basePath";
+import { enableImmediateServiceWorkerUpdate } from "./lib/pwa/enableImmediateServiceWorkerUpdate";
 
 declare let self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
 };
+
+void enableImmediateServiceWorkerUpdate({
+  claimClients: clientsClaim,
+  skipWaiting: () => self.skipWaiting(),
+});
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 


### PR DESCRIPTION
## Summary

- activate newly installed service workers immediately instead of leaving them waiting behind the previous release
- claim open clients so vite-plugin-pwa can reload them onto the matching frontend bundle
- add a regression test for the service-worker lifecycle hooks

## Root cause

The v0.8.0 backend accepts `mode` and `bridge-session` JSONL entries that v0.7.5 rejected as schema errors. The v0.7.5 frontend does not know those types. Because the custom inject-manifest service worker never called `skipWaiting()` or `clientsClaim()`, the v0.8.0 worker stayed in `waiting` and the cached v0.7.5 UI continued talking to the v0.8.0 backend, causing `Unknown conversation type`.

## Verification

- reproduced the released failure by upgrading a service-worker-controlled v0.7.5 browser session to the published v0.8.0 package: the new worker remained `waiting` and the session failed with `Unknown conversation type`
- repeated the same browser upgrade against this branch: the worker activated, reloaded the client, returned a real `mode` API entry, and rendered the session without schema or conversation-type errors
- `pnpm gatecheck check`
- `./scripts/lingui-check.sh`
- `pnpm audit`
- Node 24 pre-push checks: 120 test files / 1079 tests
- independent correctness and security reviews found no blocker

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Service worker updates now activate immediately, reducing delays when a new version is available.
  - Updated service workers can take control of open app pages without requiring users to close and reopen them.
  - Open pages receive the latest available app version sooner after an update.

- **Tests**
  - Added coverage to verify activation order, completion, and client control behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->